### PR TITLE
feature/sc 52/split joins on on using

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 tests/.coverage
 tests/.results
 .coverage
+Pipfile
 
 *.egg-info
 __pycache__

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -104,6 +104,7 @@ class Postgres(Dialect):
             r"\|\|",
             r"[+\-*/%&@|^=<>:]=?",
             r"~",
+            group(r"on", r"using") + ANY_BLANK,
         ),
         TokenType.COMMA: group(r","),
         TokenType.DOT: group(r"\."),

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -117,7 +117,7 @@ class Postgres(Dialect):
             r"with",
             expand_spaces(r"select( all| top \d+| distinct)?"),
             r"from",
-            expand_spaces(r"(natural )?(inner|((left|right|full)( outer)?))( )?join"),
+            expand_spaces(r"(natural )?((inner|((left|right|full)( outer)?)) )?join"),
             r"where",
             expand_spaces(r"group by"),
             r"having",

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -104,8 +104,12 @@ class Postgres(Dialect):
             r"\|\|",
             r"[+\-*/%&@|^=<>:]=?",
             r"~",
-            group(r"on", r"using") + ANY_BLANK,
         ),
+        TokenType.WORD_OPERATOR: group(
+            group(r"and", r"or"),
+            group(r"on", r"using"),
+        )
+        + ANY_BLANK,
         TokenType.COMMA: group(r","),
         TokenType.DOT: group(r"\."),
         TokenType.NEWLINE: group(r"\r?\n"),

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -19,6 +19,10 @@ NEWLINE: str = r"\r?\n"
 ANY_BLANK: str = group(WHITESPACES, NEWLINE, r"$")
 
 
+def expand_spaces(s: str) -> str:
+    return s.replace(" ", f"{ANY_BLANK}+")
+
+
 class SqlfmtParsingError(SqlfmtError):
     pass
 
@@ -106,20 +110,21 @@ class Postgres(Dialect):
         TokenType.NEWLINE: group(r"\r?\n"),
         TokenType.UNTERM_KEYWORD: group(
             r"with",
-            r"select( all| top \d+| distinct)?",
+            expand_spaces(r"select( all| top \d+| distinct)?"),
             r"from",
+            expand_spaces(r"(natural )?(inner|((left|right|full)( outer)?))( )?join"),
             r"where",
-            r"group by",
+            expand_spaces(r"group by"),
             r"having",
-            r"order by",
+            expand_spaces(r"order by"),
             r"limit",
             r"offset",
-            r"union( all)?",
+            expand_spaces(r"union( all)?"),
             r"when",
             r"then",
             r"else",
-            r"partition by",
-            r"rows between",
+            expand_spaces(r"partition by"),
+            expand_spaces(r"rows between"),
         )
         + ANY_BLANK,
         TokenType.NAME: group(r"\w+"),

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -76,6 +76,10 @@ class Node:
         return self.token.type == TokenType.COMMENT
 
     @property
+    def is_operator(self) -> bool:
+        return self.token.type in (TokenType.OPERATOR, TokenType.WORD_OPERATOR)
+
+    @property
     def is_newline(self) -> bool:
         return self.token.type == TokenType.NEWLINE
 
@@ -290,6 +294,7 @@ class Line:
     open_brackets: List[Token] = field(default_factory=list)
     depth_split: Optional[int] = None
     first_comma: Optional[int] = None
+    first_operator: Optional[int] = None
 
     def __str__(self) -> str:
         INDENT = " " * 4
@@ -349,6 +354,11 @@ class Line:
             and self.first_comma is None
         ):
             self.first_comma = split_index
+        elif (
+            token.type in (TokenType.OPERATOR, TokenType.WORD_OPERATOR)
+            and self.first_operator is None
+        ):
+            self.first_operator = split_index
 
         self.nodes.append(node)
 
@@ -444,6 +454,10 @@ class Line:
     @property
     def contains_comment(self) -> bool:
         return any([n.is_comment for n in self.nodes])
+
+    @property
+    def contains_operator(self) -> bool:
+        return any([n.is_operator for n in self.nodes])
 
     @property
     def contains_multiline_node(self) -> bool:

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -39,8 +39,9 @@ class LineSplitter:
         # first_comma points to the index after the comma
         elif line.first_comma and line.first_comma < line.last_content_index + 1:
             yield from self.split(line, kind="comma")
-        # nothing to split on. TODO: split on long lines with operators or
-        # just names
+        elif line_is_too_long and line.contains_operator:
+            yield from self.split(line, kind="operator")
+        # nothing to split on. TODO: split on long lines just names
         else:
             yield line
 
@@ -59,6 +60,11 @@ class LineSplitter:
                 yield line
             else:
                 yield from self.split_at_index(line, line.first_comma)
+        elif kind == "operator":
+            if not line.first_operator:
+                yield line
+            else:
+                yield from self.split_at_index(line, line.first_operator)
         else:
             yield line
 

--- a/src/sqlfmt/token.py
+++ b/src/sqlfmt/token.py
@@ -18,6 +18,7 @@ class TokenType(Enum):
     BRACKET_CLOSE = auto()
     DOUBLE_COLON = auto()
     OPERATOR = auto()
+    WORD_OPERATOR = auto()
     COMMA = auto()
     DOT = auto()
     NEWLINE = auto()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,16 @@ from sqlfmt.mode import Mode
 sys.path.append(os.path.dirname(__file__))
 
 
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """
+    Called after the Session object has been created and
+    before performing collection and entering the run test loop.
+    """
+    from tests.util import delete_results_dir
+
+    delete_results_dir()
+
+
 @pytest.fixture
 def sqlfmt_runner() -> CliRunner:
     return CliRunner(mix_stderr=False)

--- a/tests/data/unformatted/104_joins.sql
+++ b/tests/data/unformatted/104_joins.sql
@@ -3,9 +3,8 @@ three.three, four.four, five.five, six.six
 from one
 join two on one.two = two.one
 inner join "my_database"."my_schema".three as three on one.three = three.one
-left outer join four
-    on one.four = four.one 
-        and two.four = four.two 
+left outer join four on
+    one.four = four.one and two.four = four.two 
         and three.four = four.three 
         and something_else
 right join (
@@ -13,8 +12,7 @@ right join (
     from my_table where some_filter is true
 ) as five 
 using(five.id)
-natural full 
-outer join six
+natural full outer join six
 )))))__SQLFMT_OUTPUT__(((((
 select one.one, two.two, three.three, four.four, five.five, six.six
 from one

--- a/tests/data/unformatted/104_joins.sql
+++ b/tests/data/unformatted/104_joins.sql
@@ -1,0 +1,33 @@
+select one.one, two.two, 
+three.three, four.four, five.five, six.six
+from one
+join two on one.two = two.one
+inner join "my_database"."my_schema".three as three on one.three = three.one
+left outer join four
+    on one.four = four.one 
+        and two.four = four.two 
+        and three.four = four.three 
+        and something_else
+right join (
+    select id, five, six, seven, eight 
+    from my_table where some_filter is true
+) as five 
+using(five.id)
+natural full 
+outer join six
+)))))__SQLFMT_OUTPUT__(((((
+select one.one, two.two, three.three, four.four, five.five, six.six
+from one
+join two on one.two = two.one
+inner join "my_database"."my_schema".three as three on one.three = three.one
+left outer join
+    four
+    on one.four = four.one 
+    and two.four = four.two 
+    and three.four = four.three 
+    and something_else
+right join 
+    (
+        select id, five, six, seven, eight from my_table where some_filter is true
+    ) as five using(five.id)
+natural full outer join six

--- a/tests/functional_tests/test_end_to_end.py
+++ b/tests/functional_tests/test_end_to_end.py
@@ -105,7 +105,7 @@ def test_end_to_end_check_unformatted(
     result = sqlfmt_runner.invoke(sqlfmt_main, args=args)
 
     assert result
-    assert "5 files" in result.stderr
+    assert "6 files" in result.stderr
 
     assert "failed formatting check" in result.stderr
 

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -16,6 +16,7 @@ from tests.util import check_formatting, read_test_data
         "unformatted/101_multiline.sql",
         "unformatted/102_lots_of_comments.sql",
         "unformatted/103_window_functions.sql",
+        pytest.param("unformatted/104_joins.sql", marks=pytest.mark.xfail),
         "unformatted/200_base_model.sql",
     ],
 )

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -76,6 +76,7 @@ class TestPostgres:
             (TokenType.UNTERM_KEYWORD, "select all"),
             (TokenType.UNTERM_KEYWORD, "natural\n    full outer join"),
             (TokenType.UNTERM_KEYWORD, "left join"),
+            (TokenType.UNTERM_KEYWORD, "join"),
             (TokenType.NAME, "my_table_45"),
         ],
     )

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -65,6 +65,7 @@ class TestPostgres:
             (TokenType.DOUBLE_COLON, "::"),
             (TokenType.OPERATOR, "<>"),
             (TokenType.OPERATOR, "||"),
+            (TokenType.WORD_OPERATOR, "AND"),
             (TokenType.COMMA, ","),
             (TokenType.DOT, "."),
             (TokenType.NEWLINE, "\n"),

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -145,7 +145,7 @@ def test_simple_line(
     assert str(simple_line) == source_string
 
     expected_token_repr = (
-        "Token(type=<TokenType.UNTERM_KEYWORD: 19>, prefix='', token='with', "
+        "Token(type=<TokenType.UNTERM_KEYWORD: 20>, prefix='', token='with', "
         "spos=(0, 0), epos=(0, 4), line='with abc as (select * from my_table)\\n')"
     )
     assert repr(simple_line.tokens[0]) == expected_token_repr

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,10 @@
+import shutil
 from pathlib import Path
 from typing import Iterable, Iterator, List, Tuple, Union
 
 TEST_DIR = Path(__file__).parent
 BASE_DIR = TEST_DIR / "data"
+RESULTS_DIR = TEST_DIR / ".results"
 
 
 def read_test_data(relpath: Union[Path, str]) -> Tuple[str, str]:
@@ -35,6 +37,16 @@ def read_test_data(relpath: Union[Path, str]) -> Tuple[str, str]:
     return "".join(source_query).strip() + "\n", "".join(formatted_query).strip() + "\n"
 
 
+def _safe_create_results_dir() -> Path:
+    results_dir = RESULTS_DIR
+    results_dir.mkdir(exist_ok=True)
+    return results_dir
+
+
+def delete_results_dir() -> None:
+    shutil.rmtree(RESULTS_DIR, ignore_errors=True)
+
+
 def check_formatting(expected: str, actual: str, ctx: str = "") -> None:
 
     try:
@@ -44,8 +56,7 @@ def check_formatting(expected: str, actual: str, ctx: str = "") -> None:
     except AssertionError as e:
         import inspect
 
-        results_dir = p = TEST_DIR / ".results"
-        results_dir.mkdir(exist_ok=True)
+        results_dir = _safe_create_results_dir()
 
         caller = inspect.stack()[1].function
         if ctx:


### PR DESCRIPTION
- add failing test for join formatting
- add join to unterminated keywords
- add on and using as operators
- automatically delete test results before test run
- create new token type
- fix join regex

This doesn't get us all the way there; formatting test is still failing. I'm punting on the hard stuff until we get splits for operators sorted in 0.2(+). But with reasonable well-formed input, this looks nice, and it's consistent with the rest of the scheme.
