### PR TITLE
feature/sc-86/change-o-check-and-o-diff-to-check-and-diff

### DIFF
--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -23,12 +23,12 @@ def run(files: List[str], mode: Mode) -> int:
 
     display_output(str(report))
 
-    if mode.output == "update":
+    if not (mode.check or mode.diff) == "update":
         _update_source_files(results)
 
     if report.number_errored > 0:
         return 2
-    elif mode.output in ("check", "diff") and report.number_changed > 0:
+    elif (mode.check or mode.diff) and report.number_changed > 0:
         return 1
     else:
         return 0

--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -23,7 +23,7 @@ def run(files: List[str], mode: Mode) -> int:
 
     display_output(str(report))
 
-    if not (mode.check or mode.diff) == "update":
+    if not (mode.check or mode.diff):
         _update_source_files(results)
 
     if report.number_errored > 0:

--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -11,7 +11,7 @@ from sqlfmt.mode import Mode
     "--check",
     is_flag=True,
     help=(
-        "Fail with exit_code=1 if source files are not formatted to spec."
+        "Fail with an exit code of 1 if source files are not formatted to spec."
         "Do not write formatted queries to files"
     ),
 )

--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -8,15 +8,19 @@ from sqlfmt.mode import Mode
 
 @click.command()
 @click.option(
-    "-o",
-    "--output",
-    type=click.Choice(["update", "check", "diff"], case_sensitive=False),
-    default="update",
+    "--check",
+    is_flag=True,
     help=(
-        "Determines the result of running sqlfmt. "
-        "update: [default] overwrite the source files with the formatted sql. "
-        "check: fail with exit_code=1 if source files are not formatted to spec. "
-        "diff: print a diff of any formatting changes to stdout"
+        "Fail with exit_code=1 if source files are not formatted to spec."
+        "Do not write formatted queries to files"
+    ),
+)
+@click.option(
+    "--diff",
+    is_flag=True,
+    help=(
+        "Print a diff of any formatting changes to stdout. Fails like --check"
+        "on any changes. Do not write formatted queries to files"
     ),
 )
 @click.option(
@@ -39,13 +43,18 @@ from sqlfmt.mode import Mode
 )
 @click.pass_context
 def sqlfmt(
-    ctx: click.Context, files: List[str], output: str, line_length: int, verbose: bool
+    ctx: click.Context,
+    files: List[str],
+    check: bool,
+    diff: bool,
+    line_length: int,
+    verbose: bool,
 ) -> None:
     """
     sqlfmt is an opinionated CLI tool that formats your sql files
     """
     utils.display_output(f"Running sqlfmt {__version__}")
 
-    mode = Mode(line_length=line_length, output=output, verbose=verbose)
+    mode = Mode(line_length=line_length, check=check, diff=diff, verbose=verbose)
     exit_code = api.run(files=files, mode=mode)
     ctx.exit(exit_code)

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -10,5 +10,6 @@ class Mode:
     SQL_EXTENSIONS: List[str] = field(default_factory=lambda: [".sql", ".sql.jinja"])
     dialect: Dialect = field(default_factory=lambda: Postgres())
     line_length: int = 88
-    output: str = "update"
+    check: bool = False
+    diff: bool = False
     verbose: bool = False

--- a/src/sqlfmt/report.py
+++ b/src/sqlfmt/report.py
@@ -37,12 +37,14 @@ class Report:
     def __str__(self) -> str:
         report = []
         formatted = (
-            "formatted" if self.mode.output == "update" else "failed formatting check"
+            "failed formatting check"
+            if (self.mode.check or self.mode.diff)
+            else "formatted"
         )
         unchanged = (
-            "left unchanged"
-            if self.mode.output == "update"
-            else "passed formatting check"
+            "passed formatting check"
+            if (self.mode.check or self.mode.diff)
+            else "left unchanged"
         )
         if self.number_errored > 0:
             error_msg = (
@@ -59,7 +61,7 @@ class Report:
             report.append(f"{res.source_path}\n    {err}")
         for res in self.changed_results:
             report.append(f"{res.source_path} {formatted}.")
-            if self.mode.output == "diff":
+            if self.mode.diff:
                 report.append(self._generate_diff(res))
         if self.mode.verbose:
             for res in self.unchanged_results:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,19 +38,19 @@ def verbose_mode() -> Mode:
 
 @pytest.fixture
 def check_mode() -> Mode:
-    return Mode(output="check")
+    return Mode(check=True)
 
 
 @pytest.fixture
 def verbose_check_mode() -> Mode:
-    return Mode(output="check", verbose=True)
+    return Mode(check=True, verbose=True)
 
 
 @pytest.fixture
 def diff_mode() -> Mode:
-    return Mode(output="diff")
+    return Mode(diff=True)
 
 
-@pytest.fixture(params=["update", "check", "diff"])
+@pytest.fixture(params=[(False, False), (False, True), (True, False), (True, True)])
 def all_output_modes(request: Any) -> Mode:
-    return Mode(output=request.param)
+    return Mode(check=request.param[0], diff=request.param[1])

--- a/tests/functional_tests/test_end_to_end.py
+++ b/tests/functional_tests/test_end_to_end.py
@@ -47,14 +47,11 @@ def error_target(tmp_path: Path) -> Path:
         "--verbose",
         "--line-length 88",
         "-l 88",
-        "--output update",
-        "-o update",
-        "--output check",
-        "-o check",
-        "-o check -v",
-        "--output diff",
-        "-o diff",
-        "-v -o diff",
+        "--check",
+        "--check -v",
+        "--diff",
+        "-v --diff",
+        "--check --diff",
     ],
 )
 def test_end_to_end_preformatted(
@@ -84,14 +81,7 @@ def test_end_to_end_preformatted(
 
 @pytest.mark.parametrize(
     "options",
-    [
-        "--output check",
-        "-o check",
-        "-o check -v",
-        "--output diff",
-        "-o diff",
-        "-v -o diff",
-    ],
+    ["--check", "--check -v", "--diff", "-v --diff", "--diff --check"],
 )
 def test_end_to_end_check_unformatted(
     sqlfmt_runner: CliRunner, unformatted_target: Path, options: str
@@ -112,7 +102,7 @@ def test_end_to_end_check_unformatted(
     assert result.exit_code == 1
 
 
-@pytest.mark.parametrize("options", ["", "-o check"])
+@pytest.mark.parametrize("options", ["", "--check"])
 def test_end_to_end_errors(
     sqlfmt_runner: CliRunner, error_target: Path, options: str
 ) -> None:


### PR DESCRIPTION
The -output option was cleaner, but the standard from other tools is --check and --diff