### PR TITLE
bug/sc 109/false positive syntax errors in gitlab dbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - supports --quiet option
 
+### Fixes
+
+- fixes parsing of jinja tags (use lazy regex so we don't match multiple tags at once)
+- fixes issue with whitespace around jinja tags
+- fixes capitalization of word operators (on, and, etc.)
+
 ## [0.1.0] - 2021-11-08
 
 ### Features

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -67,15 +67,15 @@ class Postgres(Dialect):
 
     PATTERNS: Dict[TokenType, str] = {
         TokenType.JINJA: group(
-            r"\{\{[^\n]*\}\}",
-            r"\{%[^\n]*%\}",
-            r"\{\#[^\n]*\#\}",
+            r"\{\{[^\n]*?\}\}",
+            r"\{%[^\n]*?%\}",
+            r"\{\#[^\n]*?\#\}",
         ),
         TokenType.JINJA_START: group(r"\{[{%#]"),
         TokenType.JINJA_END: group(r"[}%#]\}"),
         TokenType.QUOTED_NAME: group(
-            r"'[^\n']*'",
-            r'"[^\n"]*"',
+            r"'[^\n']*?'",
+            r'"[^\n"]*?"',
         ),
         TokenType.COMMENT: group(r"--[^\r\n]*"),
         TokenType.COMMENT_START: group(r"/\*"),

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -283,6 +283,7 @@ class Node:
             TokenType.NAME,
             TokenType.STATEMENT_START,
             TokenType.STATEMENT_END,
+            TokenType.WORD_OPERATOR,
         ):
             return token.token.lower()
         else:

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -244,7 +244,8 @@ class Node:
             return NO_SPACE
         # names preceded by dots are namespaced identifiers. No space.
         elif (
-            token.type in (TokenType.QUOTED_NAME, TokenType.NAME, TokenType.STAR)
+            token.type
+            in (TokenType.QUOTED_NAME, TokenType.NAME, TokenType.STAR, TokenType.JINJA)
             and previous_token
             and previous_token.type == TokenType.DOT
         ):

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -156,3 +156,15 @@ class TestPostgres:
             [TokenType.NUMBER, TokenType.UNTERM_KEYWORD], line=line, lnum=0, skipchars=6
         )
         assert actual_token == expected_token
+
+    def test_match_first_jinja_Tag(self, postgres: Postgres) -> None:
+        source_string = (
+            "{{ event_cte.source_cte_name}}.{{ event_cte.primary_key }} "
+            "|| '-' || '{{ event_cte.event_name }}'"
+        )
+        prog = postgres.programs[TokenType.JINJA]
+        match = prog.match(source_string)
+
+        assert match is not None
+        start, end = match.span(1)
+        assert source_string[start:end] == "{{ event_cte.source_cte_name}}"

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -384,3 +384,15 @@ def test_identifier_whitespace(default_mode: Mode) -> None:
     q = Query.from_source(source_string=source_string, mode=default_mode)
     parsed_string = "".join(str(line) for line in q.lines)
     assert source_string == parsed_string
+
+
+def test_capitalization(default_mode: Mode) -> None:
+    source_string = (
+        "SELECT A, B, \"C\", {{ D }}, e, 'f', 'G'\n" 'fROM "H"."j" Join I ON k And L\n'
+    )
+    expected = (
+        "select a, b, \"C\", {{ D }}, e, 'f', 'G'\n" 'from "H"."j" join i on k and l\n'
+    )
+    q = Query.from_source(source_string=source_string, mode=default_mode)
+    parsed_string = "".join(str(line) for line in q.lines)
+    assert parsed_string == expected

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -364,3 +364,23 @@ def test_closes_bracket_from_previous_line(
     result = [line.closes_bracket_from_previous_line for line in q.lines]
     expected = [False, False, False, False, False, False, True, False, True]
     assert result == expected
+
+
+def test_identifier_whitespace(default_mode: Mode) -> None:
+    """
+    Ensure we do not inject spaces into qualified identifier names
+    """
+    source_string = (
+        "my_schema.my_table,\n"
+        "my_schema.*,\n"
+        "{{ my_schema }}.my_table,\n"
+        "my_schema.{{ my_table }},\n"
+        "my_database.my_schema.my_table,\n"
+        'my_schema."my_table",\n'
+        '"my_schema".my_table,\n'
+        '"my_schema"."my_table",\n'
+        '"my_schema".*,\n'
+    )
+    q = Query.from_source(source_string=source_string, mode=default_mode)
+    parsed_string = "".join(str(line) for line in q.lines)
+    assert source_string == parsed_string


### PR DESCRIPTION
- fix: use lazy regex for jinja tags
- fix: do not insert space before jinja tag if it is a relation name
- fix: lowercase word operators
- update changelog
