### PR TITLE
Fix: Improve Jinja Whitespace Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes
+
+-   sqlfmt is now more conservative about preserving whitespace around jinja expressions when we remove newlines ([#162](https://github.com/tconbeer/sqlfmt/issues/162), [#165](https://github.com/tconbeer/sqlfmt/issues/165))
+-   Jinja blocks are now dedented before line merging, instead of after. This results in small changes to formatted output in some cases where jinja blocks are used
+-   Fixes an issue where jinja else and elif statements could cause unstable formatting. May impact whitespace for the tokens following `{% else %}` and `{% elif %}` statements
+
 ## [0.7.0] - 2022-04-24
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ Want more examples? See the `tests/data` directory, or go to http://sqlfmt.com t
 [![Maintainability](https://api.codeclimate.com/v1/badges/8928f6662a67b8eaf092/maintainability)](https://codeclimate.com/github/tconbeer/sqlfmt/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8928f6662a67b8eaf092/test_coverage)](https://codeclimate.com/github/tconbeer/sqlfmt/test_coverage)
 
+### Providing Feedback
+
+We'd love to hear from you! [Open an Issue](https://github.com/tconbeer/sqlfmt/issues/new/choose) to request new features, report bad formatting, or say hello.
+
 ### Setting up Your Dev Environment and Running Tests
 
 1. Install [Poetry](https://python-poetry.org/docs/#installation) if you don't have it already. You may also need or want pyenv, make, and gcc. A complete setup from a fresh install of Ubuntu can be found [here](https://github.com/tconbeer/linux_setup)

--- a/src/sqlfmt/formatter.py
+++ b/src/sqlfmt/formatter.py
@@ -28,8 +28,8 @@ class QueryFormatter:
 
     def _format_jinja(self, lines: List[Line]) -> List[Line]:
         """
-        Formats the contents of jinja tags (the code between)
-        the curlies by mutating existing jinja nodes
+        Formats the contents of jinja tags (the code between
+        the curlies) by mutating existing jinja nodes
         """
         formatter = JinjaFormatter(mode=self.mode)
         for line in lines:
@@ -73,16 +73,16 @@ class QueryFormatter:
         Applies 4 transformations to a Query:
         1. Splits lines
         2. Formats jinja tags
-        3. Merges lines
-        4. Dedents jinja block tags to match their least-indented contents
+        3. Dedents jinja block tags to match their least-indented contents
+        4. Merges lines
         """
         lines = raw_query.lines
 
         pipeline = [
             self._split_lines,
             self._format_jinja,
-            self._merge_lines,
             self._dedent_jinja_blocks,
+            self._merge_lines,
         ]
 
         for transform in pipeline:

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -190,7 +190,6 @@ class Line:
         splitting and merging
         """
         if nodes:
-            nodes[0].previous_node = previous_node
             line = Line(
                 previous_node=previous_node,
                 nodes=nodes,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -76,8 +76,8 @@ def get_projects() -> List[SQLProject]:
             name="dbt_utils",
             git_url="https://github.com/dbt-labs/dbt-utils.git",
             git_ref="51ed999a44fcc7f9f502be11e5f190f5bc84ba4b",  # Jan 17, 2022
-            expected_changed=114,
-            expected_unchanged=0,
+            expected_changed=113,
+            expected_unchanged=1,
             expected_errored=1,
             sub_directory=Path(""),
         ),

--- a/tests/data/unformatted/107_jinja_blocks.sql
+++ b/tests/data/unformatted/107_jinja_blocks.sql
@@ -41,8 +41,8 @@ with
     base as (
         select *
         from
-            {% if "Hello" in block_o_text %}{{ ref("hello") }}
-            {% else %}{{ ref("goodbye") }}
+            {% if "Hello" in block_o_text %} {{ ref("hello") }}
+            {% else %} {{ ref("goodbye") }}
             {% endif %}
     ),
     joined as (
@@ -51,8 +51,7 @@ with
             {{ model }}.column_a as {{ model }}_field
             {%- if not loop.last -%},{%- endif %}
             {% endfor %}
-        from
-            base
+        from base
         {% for model in list_o_models %}
         join {{ model }} on base.{{ model }}_id = {{ model }}.id
         {% endfor %}

--- a/tests/data/unformatted/113_utils_group_by.sql
+++ b/tests/data/unformatted/113_utils_group_by.sql
@@ -1,0 +1,29 @@
+select field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    count(*)
+from my_table
+where something_is_true
+{{ dbt_utils.group_by(10) }} -- todo: keep line break
+)))))__SQLFMT_OUTPUT__(((((
+select
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    field_a,
+    count(*)
+from my_table
+where something_is_true {{ dbt_utils.group_by(10) }}  -- todo: keep line break

--- a/tests/data/unformatted/202_unpivot_macro.sql
+++ b/tests/data/unformatted/202_unpivot_macro.sql
@@ -1,0 +1,97 @@
+-- from https://github.com/dbt-labs/dbt-utils/blob/33299334a305d0acb99ebee8cc2eb6eb2ba5ca31/macros/sql/unpivot.sql
+{% macro default__unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', table=none) -%}
+
+  {%- set exclude = exclude if exclude is not none else [] %}
+  {%- set remove = remove if remove is not none else [] %}
+
+  {%- set include_cols = [] %}
+
+  {%- set table_columns = {} %}
+
+  {%- do table_columns.update({relation: []}) %}
+
+  {%- do dbt_utils._is_relation(relation, 'unpivot') -%}
+  {%- do dbt_utils._is_ephemeral(relation, 'unpivot') -%}
+  {%- set cols = adapter.get_columns_in_relation(relation) %}
+
+  {%- for col in cols -%}
+    {%- if col.column.lower() not in remove|map('lower') and col.column.lower() not in exclude|map('lower') -%}
+      {% do include_cols.append(col) %}
+    {%- endif %}
+  {%- endfor %}
+
+
+  {%- for col in include_cols -%}
+    select
+      {%- for exclude_col in exclude %}
+        {{ exclude_col }},
+      {%- endfor %}
+
+      cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as {{ field_name }},
+      cast(  {% if col.data_type == 'boolean' %}
+           {{ dbt_utils.cast_bool_to_text(col.column) }}
+             {% else %}
+           {{ col.column }}
+             {% endif %}
+           as {{ cast_to }}) as {{ value_name }}
+
+    from {{ relation }}
+
+    {% if not loop.last -%}
+      union all
+    {% endif -%}
+  {%- endfor -%}
+
+{%- endmacro %}
+)))))__SQLFMT_OUTPUT__(((((
+-- from
+-- https://github.com/dbt-labs/dbt-utils/blob/33299334a305d0acb99ebee8cc2eb6eb2ba5ca31/macros/sql/unpivot.sql
+{% macro default__unpivot(
+    relation=none,
+    cast_to="varchar",
+    exclude=none,
+    remove=none,
+    field_name="field_name",
+    value_name="value",
+    table=none,
+) -%}
+
+{%- set exclude = exclude if exclude is not none else [] %}
+{%- set remove = remove if remove is not none else [] %}
+
+{%- set include_cols = [] %}
+
+{%- set table_columns = {} %}
+
+{%- do table_columns.update({relation: []}) %}
+
+{%- do dbt_utils._is_relation(relation, "unpivot") -%}
+{%- do dbt_utils._is_ephemeral(relation, "unpivot") -%}
+{%- set cols = adapter.get_columns_in_relation(relation) %}
+
+{%- for col in cols -%}
+{%- if col.column.lower() not in remove | map(
+    "lower"
+) and col.column.lower() not in exclude | map("lower") -%}
+{% do include_cols.append(col) %}
+{%- endif %}
+{%- endfor %}
+
+
+{%- for col in include_cols -%}
+select
+    {%- for exclude_col in exclude %} {{ exclude_col }}, {%- endfor %}
+
+    cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as {{ field_name }},
+    cast(
+        {% if col.data_type == "boolean" %}{{ dbt_utils.cast_bool_to_text(col.column) }}
+        {% else %}{{ col.column }}
+        {% endif %} as {{ cast_to }}
+    ) as {{ value_name }}
+
+from {{ relation }}
+
+{% if not loop.last -%} union all {% endif -%}
+{%- endfor -%}
+
+{%- endmacro %}

--- a/tests/functional_tests/test_end_to_end.py
+++ b/tests/functional_tests/test_end_to_end.py
@@ -112,7 +112,7 @@ def test_end_to_end_check_unformatted(
     result = sqlfmt_runner.invoke(sqlfmt_main, args=args)
 
     assert result
-    assert "16 files" in result.stderr
+    assert "18 files" in result.stderr
     assert "failed formatting check" in result.stderr
 
     if "-q" in options or "--quiet" in options:

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -25,8 +25,10 @@ from tests.util import check_formatting, read_test_data
         "unformatted/110_other_identifiers.sql",
         "unformatted/111_chained_boolean_between.sql",
         "unformatted/112_semicolons.sql",
+        "unformatted/113_utils_group_by.sql",
         "unformatted/200_base_model.sql",
         "unformatted/201_basic_snapshot.sql",
+        "unformatted/202_unpivot_macro.sql",
         "unformatted/300_jinjafmt.sql",
     ],
 )


### PR DESCRIPTION
-   sqlfmt is now more conservative about preserving whitespace around jinja expressions when we remove newlines (closes #162, #165)
-   Jinja blocks are now dedented before line merging, instead of after. This results in small changes to formatted output in some cases where jinja blocks are used
-   Fixes an issue where jinja else and elif statements could cause unstable formatting. May impact whitespace for the tokens following `{% else %}` and `{% elif %}` statements