### PR TITLE
fix: remove trailing commas added to macro definitions by black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+-   fixes issue where jinjafmt would insert a trailing comma into multiline macro definitions, causing dbt compiling errors ([#156](https://github.com/tconbeer/sqlfmt/issues/156))
 -   fixes issue causing unstable formatting of multiline jinja tags when black is unable to parse the tag ([#176](https://github.com/tconbeer/sqlfmt/issues/176))
 -   fixes issue for developers where pre-commit hooks would not install
 

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -75,7 +75,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="dbt_utils",
             git_url="https://github.com/tconbeer/dbt-utils.git",
-            git_ref="7c4d7f2a8dca533207b4e8a63a919f73eb0bb136",  # sqlfmt 0.8.0
+            git_ref="ddbb104f2168bab9a1c1a95c3859a52222741641",  # sqlfmt 59e52a1
             expected_changed=3,
             expected_unchanged=128,
             expected_errored=0,

--- a/tests/data/unformatted/202_unpivot_macro.sql
+++ b/tests/data/unformatted/202_unpivot_macro.sql
@@ -53,7 +53,7 @@
     remove=none,
     field_name="field_name",
     value_name="value",
-    table=none,
+    table=none
 ) -%}
 
 {%- set exclude = exclude if exclude is not none else [] %}


### PR DESCRIPTION
closes #156 