### PR TITLE
fix/issue 175/unstable jinja and operators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ python = "^3.7"
 click = "^8.0"
 platformdirs = "^2.4.0"
 importlib_metadata = { version = "*", python = "<3.8" }
-"backports.cached-property" = { version = "*", python = "<3.8" }
 gitpython = { version = "^3.1.24", optional = true }
 black = { version = "*", optional = true }
 tomli = { version = "^2.0.1", python = "<3.11" }

--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -1,15 +1,9 @@
 import re
-import sys
 from dataclasses import dataclass
 from typing import ClassVar, Iterator, Tuple
 
 from sqlfmt.exception import InlineCommentException
 from sqlfmt.token import Token
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
 
 
 @dataclass
@@ -26,7 +20,7 @@ class Comment:
     def __str__(self) -> str:
         return self._calc_str
 
-    @cached_property
+    @property
     def _calc_str(self) -> str:
         """
         Returns the contents of the comment token plus a trailing newline,

--- a/src/sqlfmt/formatter.py
+++ b/src/sqlfmt/formatter.py
@@ -19,7 +19,7 @@ class QueryFormatter:
         Splits lines to make line depth consistent and syntax
         apparent
         """
-        splitter = LineSplitter(mode=self.mode)
+        splitter = LineSplitter()
         new_lines = []
         for line in lines:
             splits = list(splitter.maybe_split(line))
@@ -32,9 +32,10 @@ class QueryFormatter:
         the curlies) by mutating existing jinja nodes
         """
         formatter = JinjaFormatter(mode=self.mode)
+        new_lines: List[Line] = []
         for line in lines:
-            formatter.format_line(line)
-        return lines
+            new_lines.extend(formatter.format_line(line))
+        return new_lines
 
     def _merge_lines(self, lines: List[Line]) -> List[Line]:
         """

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
@@ -6,11 +5,6 @@ from sqlfmt.comment import Comment
 from sqlfmt.exception import InlineCommentException
 from sqlfmt.node import Node
 from sqlfmt.token import Token, TokenType
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
 
 
 @dataclass
@@ -28,7 +22,7 @@ class Line:
     def __str__(self) -> str:
         return self._calc_str
 
-    @cached_property
+    @property
     def _calc_str(self) -> str:
         """
         A Line is printed in one of three ways:
@@ -40,8 +34,6 @@ class Line:
 
         Does not include any Comments; for those, use the render_with_comments
         method
-
-        Cached for performance.
         """
         if self.is_blank_line:
             return "\n"
@@ -216,7 +208,7 @@ class Line:
             tokens.append(node.token)
         return tokens
 
-    @cached_property
+    @property
     def is_blank_line(self) -> bool:
         if (
             len(self.nodes) == 1
@@ -270,7 +262,7 @@ class Line:
     def contains_operator(self) -> bool:
         return any([n.is_operator for n in self.nodes])
 
-    @cached_property
+    @property
     def contains_jinja(self) -> bool:
         return any([n.is_jinja for n in self.nodes])
 

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -17,8 +17,8 @@ class LineMerger:
     def create_merged_line(self, lines: List[Line]) -> List[Line]:
         """
         Returns a new line by merging together all nodes in lines. Raises an
-        exception if the returned line would be too long, would be empty,
-        or would attempt to merge a multiline token.
+        exception if the returned line would be too long, empty, or the nodes in
+        any of the lines violate the rules in _raise_unmergeable.
         """
 
         # if the child is just one below the parent, we're trying to
@@ -65,8 +65,18 @@ class LineMerger:
             ]
             if content_nodes:
                 final_newline = line.nodes[-1]
-                allow_multiline = False
                 nodes.extend(content_nodes)
+                # we can merge lines containing multiline nodes iff:
+                # 1. the multiline node is on the first line (allow_multiline
+                #    is initialized to True)
+                # 2. the multiline node is on the second line and follows a
+                #    standalone operator
+                if not (
+                    allow_multiline
+                    and len(content_nodes) == 1
+                    and content_nodes[0].is_operator
+                ):
+                    allow_multiline = False
             comments.extend(line.comments)
 
         if not nodes or not final_newline:

--- a/src/sqlfmt/node.py
+++ b/src/sqlfmt/node.py
@@ -1,14 +1,8 @@
-import sys
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from sqlfmt.exception import SqlfmtBracketError
 from sqlfmt.token import Token, TokenType
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
 
 
 @dataclass
@@ -163,7 +157,7 @@ class Node:
             TokenType.JINJA_BLOCK_END,
         )
 
-    @cached_property
+    @property
     def is_operator(self) -> bool:
         return (
             self.token.type
@@ -209,7 +203,7 @@ class Node:
         """
         return self.token.type == TokenType.WORD_OPERATOR and self.value == "between"
 
-    @cached_property
+    @property
     def has_preceding_between_operator(self) -> bool:
         """
         True if this node has a preceding "between" operator at the same depth
@@ -239,7 +233,7 @@ class Node:
     def is_newline(self) -> bool:
         return self.token.type == TokenType.NEWLINE
 
-    @cached_property
+    @property
     def is_multiline(self) -> bool:
         if (
             self.token.type

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -2,14 +2,11 @@ from dataclasses import dataclass
 from typing import Iterator
 
 from sqlfmt.line import Line
-from sqlfmt.mode import Mode
 from sqlfmt.node import Node
 
 
 @dataclass
 class LineSplitter:
-    mode: Mode
-
     def maybe_split(self, line: Line) -> Iterator[Line]:
         """
         Evaluates a line for splitting. If line matches criteria for splitting,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,18 +30,18 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="22075b50cd2fd12d0ca20d2175e83dcf228d3b38",  # sqlfmt fb99833
-            expected_changed=15,
-            expected_unchanged=2402,
+            git_ref="4d75449eeb2d7a97dbb63fae4458de19dd2a382a",  # sqlfmt 0d3b30e
+            expected_changed=4,
+            expected_unchanged=2413,
             expected_errored=0,
             sub_directory=Path("transform/snowflake-dbt/"),
         ),
         SQLProject(
             name="rittman",
             git_url="https://github.com/tconbeer/rittman_ra_data_warehouse.git",
-            git_ref="4496716aa77860bab39bfd0cab2f3a360cb1b9b9",  # sqlfmt fb99833
-            expected_changed=14,
-            expected_unchanged=293,
+            git_ref="0d5492b2526d5830a94037f336223fd4e0e3fbd4",  # sqlfmt 0d3b30e
+            expected_changed=0,
+            expected_unchanged=307,
             expected_errored=4,  # true mismatching brackets
             sub_directory=Path(""),
         ),
@@ -76,8 +76,8 @@ def get_projects() -> List[SQLProject]:
             name="dbt_utils",
             git_url="https://github.com/tconbeer/dbt-utils.git",
             git_ref="1afba0e868e4d6221bb14e3c27dde1fe3fa3c405",  # sqlfmt fb99833
-            expected_changed=4,
-            expected_unchanged=127,
+            expected_changed=1,
+            expected_unchanged=130,
             expected_errored=0,
             sub_directory=Path(""),
         ),

--- a/tests/data/unformatted/213_gitlab_fct_sales_funnel_target.sql
+++ b/tests/data/unformatted/213_gitlab_fct_sales_funnel_target.sql
@@ -1,0 +1,378 @@
+# COPYRIGHT GITLAB, USED UNDER MIT LICENSE
+# SEE: https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
+{{ simple_cte([
+      ('sfdc_user_hierarchy_live', 'prep_crm_user_hierarchy_live'),
+      ('sfdc_user_hierarchy_stamped', 'prep_crm_user_hierarchy_stamped'),
+      ('sales_qualified_source', 'prep_sales_qualified_source'),
+      ('order_type', 'prep_order_type'),
+      ('alliance_type', 'prep_alliance_type'),
+      ('channel_type', 'prep_channel_type'),
+      ('date_details_source', 'date_details_source')
+])}}
+
+, date AS (
+
+   SELECT DISTINCT
+     fiscal_month_name_fy,
+     fiscal_year,
+     first_day_of_month
+   FROM date_details_source
+
+), target_matrix AS (
+
+    SELECT
+      sheetload_sales_funnel_targets_matrix_source.*,
+      date.first_day_of_month,
+      date.fiscal_year,
+      {{ get_keyed_nulls('sales_qualified_source.dim_sales_qualified_source_id') }}   AS dim_sales_qualified_source_id,
+      {{ get_keyed_nulls('order_type.dim_order_type_id') }}                           AS dim_order_type_id
+    FROM {{ ref('sheetload_sales_funnel_targets_matrix_source' )}}
+    LEFT JOIN date
+      ON {{ sales_funnel_text_slugify("sheetload_sales_funnel_targets_matrix_source.month") }} = {{ sales_funnel_text_slugify("date.fiscal_month_name_fy") }}
+    LEFT JOIN sales_qualified_source
+      ON {{ sales_funnel_text_slugify("sheetload_sales_funnel_targets_matrix_source.opportunity_source") }} = {{ sales_funnel_text_slugify("sales_qualified_source.sales_qualified_source_name") }}
+    LEFT JOIN order_type
+      ON {{ sales_funnel_text_slugify("sheetload_sales_funnel_targets_matrix_source.order_type") }} = {{ sales_funnel_text_slugify("order_type.order_type_name") }}
+
+), fy22_user_hierarchy AS (
+/* 
+For FY22, targets in the sheetload file were set at the user_area grain, so we join to the stamped hierarchy on the user_area. We also want to find the last user_area in the fiscal year
+because if there were multiple hierarchies for this user_area, the last one created is assumed to be the correct version. It is necessary to have a 1:1 relationship between area in the target
+sheetload and user_area in the hierarchy so the targets do not fan out.
+*/
+
+    SELECT *
+    FROM sfdc_user_hierarchy_stamped
+    WHERE fiscal_year = 2022
+      AND is_last_user_area_in_fiscal_year = 1
+
+), fy23_and_beyond_user_hierarchy AS (
+/* 
+For FY23 and beyond, targets in the sheetload file were set at the user_segment_geo_region_area grain, so we join to the stamped hierarchy on the user_segment_geo_region_area.
+*/
+
+    SELECT *
+    FROM sfdc_user_hierarchy_stamped
+    WHERE fiscal_year > 2022
+      AND is_last_user_hierarchy_in_fiscal_year = 1
+
+), unioned_targets AS (
+
+    SELECT
+      target_matrix.kpi_name,
+      target_matrix.first_day_of_month,
+      target_matrix.dim_sales_qualified_source_id,
+      target_matrix.opportunity_source,
+      target_matrix.dim_order_type_id,
+      target_matrix.order_type, 
+      target_matrix.fiscal_year,
+      target_matrix.allocated_target,
+      fy22_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped,
+      fy22_user_hierarchy.dim_crm_user_hierarchy_stamped_id,
+      fy22_user_hierarchy.dim_crm_opp_owner_sales_segment_stamped_id,
+      fy22_user_hierarchy.crm_opp_owner_sales_segment_stamped,
+      fy22_user_hierarchy.dim_crm_opp_owner_geo_stamped_id,
+      fy22_user_hierarchy.crm_opp_owner_geo_stamped,
+      fy22_user_hierarchy.dim_crm_opp_owner_region_stamped_id,
+      fy22_user_hierarchy.crm_opp_owner_region_stamped,
+      fy22_user_hierarchy.dim_crm_opp_owner_area_stamped_id,
+      fy22_user_hierarchy.crm_opp_owner_area_stamped
+    FROM target_matrix
+    LEFT JOIN fy22_user_hierarchy
+      ON {{ sales_funnel_text_slugify("target_matrix.area") }} = {{ sales_funnel_text_slugify("fy22_user_hierarchy.crm_opp_owner_area_stamped") }}
+    WHERE target_matrix.fiscal_year = 2022 
+
+    UNION ALL
+
+    SELECT
+      target_matrix.kpi_name,
+      target_matrix.first_day_of_month,
+      target_matrix.dim_sales_qualified_source_id,
+      target_matrix.opportunity_source,
+      target_matrix.dim_order_type_id,
+      target_matrix.order_type, 
+      target_matrix.fiscal_year,
+      target_matrix.allocated_target,
+      fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped,
+      fy23_and_beyond_user_hierarchy.dim_crm_user_hierarchy_stamped_id,
+      fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_sales_segment_stamped_id,
+      fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_stamped,
+      fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_geo_stamped_id,
+      fy23_and_beyond_user_hierarchy.crm_opp_owner_geo_stamped,
+      fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_region_stamped_id,
+      fy23_and_beyond_user_hierarchy.crm_opp_owner_region_stamped,
+      fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_area_stamped_id,
+      fy23_and_beyond_user_hierarchy.crm_opp_owner_area_stamped
+    FROM target_matrix
+    LEFT JOIN fy23_and_beyond_user_hierarchy
+      ON {{ sales_funnel_text_slugify("target_matrix.area") }} = {{ sales_funnel_text_slugify("fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped") }}
+        AND target_matrix.fiscal_year = fy23_and_beyond_user_hierarchy.fiscal_year
+    WHERE target_matrix.fiscal_year > 2022 
+
+), final_targets AS (
+
+     SELECT
+
+     {{ dbt_utils.surrogate_key(['unioned_targets.crm_opp_owner_sales_segment_geo_region_area_stamped', 
+                                 'unioned_targets.fiscal_year', 
+                                 'unioned_targets.kpi_name', 
+                                 'unioned_targets.first_day_of_month', 
+                                 'unioned_targets.opportunity_source',
+                                 'unioned_targets.order_type',
+                                 ]) }}                           AS sales_funnel_target_id,
+     unioned_targets.kpi_name,
+     unioned_targets.first_day_of_month,
+     unioned_targets.fiscal_year,
+     unioned_targets.opportunity_source                                                                                             AS sales_qualified_source,
+     unioned_targets.dim_sales_qualified_source_id,
+     unioned_targets.order_type,
+     unioned_targets.dim_order_type_id,
+     unioned_targets.crm_opp_owner_sales_segment_geo_region_area_stamped                                                             AS crm_user_sales_segment_geo_region_area,
+     COALESCE(sfdc_user_hierarchy_live.dim_crm_user_hierarchy_live_id, unioned_targets.dim_crm_user_hierarchy_stamped_id)           AS dim_crm_user_hierarchy_live_id,
+     COALESCE(sfdc_user_hierarchy_live.dim_crm_user_sales_segment_id, unioned_targets.dim_crm_opp_owner_sales_segment_stamped_id)   AS dim_crm_user_sales_segment_id,
+     COALESCE(sfdc_user_hierarchy_live.dim_crm_user_geo_id, unioned_targets.dim_crm_opp_owner_geo_stamped_id)                       AS dim_crm_user_geo_id,
+     COALESCE(sfdc_user_hierarchy_live.dim_crm_user_region_id, unioned_targets.dim_crm_opp_owner_region_stamped_id)                 AS dim_crm_user_region_id,
+     COALESCE(sfdc_user_hierarchy_live.dim_crm_user_area_id, unioned_targets.dim_crm_opp_owner_area_stamped_id)                     AS dim_crm_user_area_id,
+     unioned_targets.dim_crm_user_hierarchy_stamped_id,
+     unioned_targets.dim_crm_opp_owner_sales_segment_stamped_id,
+     unioned_targets.dim_crm_opp_owner_geo_stamped_id,
+     unioned_targets.dim_crm_opp_owner_region_stamped_id,
+     unioned_targets.dim_crm_opp_owner_area_stamped_id,
+     SUM(unioned_targets.allocated_target)                                                                                          AS allocated_target
+
+    FROM unioned_targets
+    LEFT JOIN sfdc_user_hierarchy_live
+      ON unioned_targets.dim_crm_user_hierarchy_stamped_id = sfdc_user_hierarchy_live.dim_crm_user_hierarchy_live_id
+    {{ dbt_utils.group_by(n=19) }}
+
+)
+
+{{ dbt_audit(
+    cte_ref="final_targets",
+    created_by="@mcooperDD",
+    updated_by="@michellecooper",
+    created_date="2020-12-18",
+    updated_date="2022-03-07"
+) }}
+)))))__SQLFMT_OUTPUT__(((((
+# COPYRIGHT GITLAB, USED UNDER MIT LICENSE
+# SEE:
+# https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
+{{
+    simple_cte(
+        [
+            ("sfdc_user_hierarchy_live", "prep_crm_user_hierarchy_live"),
+            ("sfdc_user_hierarchy_stamped", "prep_crm_user_hierarchy_stamped"),
+            ("sales_qualified_source", "prep_sales_qualified_source"),
+            ("order_type", "prep_order_type"),
+            ("alliance_type", "prep_alliance_type"),
+            ("channel_type", "prep_channel_type"),
+            ("date_details_source", "date_details_source"),
+        ]
+    )
+}},
+date as (
+
+    select distinct fiscal_month_name_fy, fiscal_year, first_day_of_month
+    from date_details_source
+
+),
+target_matrix as (
+
+    select
+        sheetload_sales_funnel_targets_matrix_source.*,
+        date.first_day_of_month,
+        date.fiscal_year,
+        {{ get_keyed_nulls("sales_qualified_source.dim_sales_qualified_source_id") }}
+        as dim_sales_qualified_source_id,
+        {{ get_keyed_nulls("order_type.dim_order_type_id") }} as dim_order_type_id
+    from {{ ref("sheetload_sales_funnel_targets_matrix_source") }}
+    left join
+        date
+        on
+        {{
+            sales_funnel_text_slugify(
+                "sheetload_sales_funnel_targets_matrix_source.month"
+            )
+        }}
+        = {{ sales_funnel_text_slugify("date.fiscal_month_name_fy") }}
+    left join
+        sales_qualified_source
+        on
+        {{
+            sales_funnel_text_slugify(
+                "sheetload_sales_funnel_targets_matrix_source.opportunity_source"
+            )
+        }}
+        =
+        {{
+            sales_funnel_text_slugify(
+                "sales_qualified_source.sales_qualified_source_name"
+            )
+        }}
+    left join
+        order_type
+        on
+        {{
+            sales_funnel_text_slugify(
+                "sheetload_sales_funnel_targets_matrix_source.order_type"
+            )
+        }}
+        = {{ sales_funnel_text_slugify("order_type.order_type_name") }}
+
+),
+fy22_user_hierarchy as (
+    /* 
+For FY22, targets in the sheetload file were set at the user_area grain, so we join to the stamped hierarchy on the user_area. We also want to find the last user_area in the fiscal year
+because if there were multiple hierarchies for this user_area, the last one created is assumed to be the correct version. It is necessary to have a 1:1 relationship between area in the target
+sheetload and user_area in the hierarchy so the targets do not fan out.
+*/
+    select *
+    from sfdc_user_hierarchy_stamped
+    where fiscal_year = 2022 and is_last_user_area_in_fiscal_year = 1
+
+),
+fy23_and_beyond_user_hierarchy as (
+    /* 
+For FY23 and beyond, targets in the sheetload file were set at the user_segment_geo_region_area grain, so we join to the stamped hierarchy on the user_segment_geo_region_area.
+*/
+    select *
+    from sfdc_user_hierarchy_stamped
+    where fiscal_year > 2022 and is_last_user_hierarchy_in_fiscal_year = 1
+
+),
+unioned_targets as (
+
+    select
+        target_matrix.kpi_name,
+        target_matrix.first_day_of_month,
+        target_matrix.dim_sales_qualified_source_id,
+        target_matrix.opportunity_source,
+        target_matrix.dim_order_type_id,
+        target_matrix.order_type,
+        target_matrix.fiscal_year,
+        target_matrix.allocated_target,
+        fy22_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped,
+        fy22_user_hierarchy.dim_crm_user_hierarchy_stamped_id,
+        fy22_user_hierarchy.dim_crm_opp_owner_sales_segment_stamped_id,
+        fy22_user_hierarchy.crm_opp_owner_sales_segment_stamped,
+        fy22_user_hierarchy.dim_crm_opp_owner_geo_stamped_id,
+        fy22_user_hierarchy.crm_opp_owner_geo_stamped,
+        fy22_user_hierarchy.dim_crm_opp_owner_region_stamped_id,
+        fy22_user_hierarchy.crm_opp_owner_region_stamped,
+        fy22_user_hierarchy.dim_crm_opp_owner_area_stamped_id,
+        fy22_user_hierarchy.crm_opp_owner_area_stamped
+    from target_matrix
+    left join
+        fy22_user_hierarchy
+        on {{ sales_funnel_text_slugify("target_matrix.area") }}
+        =
+        {{ sales_funnel_text_slugify("fy22_user_hierarchy.crm_opp_owner_area_stamped") }}
+    where target_matrix.fiscal_year = 2022
+
+    union all
+
+    select
+        target_matrix.kpi_name,
+        target_matrix.first_day_of_month,
+        target_matrix.dim_sales_qualified_source_id,
+        target_matrix.opportunity_source,
+        target_matrix.dim_order_type_id,
+        target_matrix.order_type,
+        target_matrix.fiscal_year,
+        target_matrix.allocated_target,
+        fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped,
+        fy23_and_beyond_user_hierarchy.dim_crm_user_hierarchy_stamped_id,
+        fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_sales_segment_stamped_id,
+        fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_stamped,
+        fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_geo_stamped_id,
+        fy23_and_beyond_user_hierarchy.crm_opp_owner_geo_stamped,
+        fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_region_stamped_id,
+        fy23_and_beyond_user_hierarchy.crm_opp_owner_region_stamped,
+        fy23_and_beyond_user_hierarchy.dim_crm_opp_owner_area_stamped_id,
+        fy23_and_beyond_user_hierarchy.crm_opp_owner_area_stamped
+    from target_matrix
+    left join
+        fy23_and_beyond_user_hierarchy
+        on {{ sales_funnel_text_slugify("target_matrix.area") }}
+        =
+        {{
+            sales_funnel_text_slugify(
+                "fy23_and_beyond_user_hierarchy.crm_opp_owner_sales_segment_geo_region_area_stamped"
+            )
+        }}
+        and target_matrix.fiscal_year = fy23_and_beyond_user_hierarchy.fiscal_year
+    where target_matrix.fiscal_year > 2022
+
+),
+final_targets as (
+
+    select
+
+        {{
+            dbt_utils.surrogate_key(
+                [
+                    "unioned_targets.crm_opp_owner_sales_segment_geo_region_area_stamped",
+                    "unioned_targets.fiscal_year",
+                    "unioned_targets.kpi_name",
+                    "unioned_targets.first_day_of_month",
+                    "unioned_targets.opportunity_source",
+                    "unioned_targets.order_type",
+                ]
+            )
+        }}
+        as sales_funnel_target_id,
+        unioned_targets.kpi_name,
+        unioned_targets.first_day_of_month,
+        unioned_targets.fiscal_year,
+        unioned_targets.opportunity_source as sales_qualified_source,
+        unioned_targets.dim_sales_qualified_source_id,
+        unioned_targets.order_type,
+        unioned_targets.dim_order_type_id,
+        unioned_targets.crm_opp_owner_sales_segment_geo_region_area_stamped
+        as crm_user_sales_segment_geo_region_area,
+        coalesce(
+            sfdc_user_hierarchy_live.dim_crm_user_hierarchy_live_id,
+            unioned_targets.dim_crm_user_hierarchy_stamped_id
+        ) as dim_crm_user_hierarchy_live_id,
+        coalesce(
+            sfdc_user_hierarchy_live.dim_crm_user_sales_segment_id,
+            unioned_targets.dim_crm_opp_owner_sales_segment_stamped_id
+        ) as dim_crm_user_sales_segment_id,
+        coalesce(
+            sfdc_user_hierarchy_live.dim_crm_user_geo_id,
+            unioned_targets.dim_crm_opp_owner_geo_stamped_id
+        ) as dim_crm_user_geo_id,
+        coalesce(
+            sfdc_user_hierarchy_live.dim_crm_user_region_id,
+            unioned_targets.dim_crm_opp_owner_region_stamped_id
+        ) as dim_crm_user_region_id,
+        coalesce(
+            sfdc_user_hierarchy_live.dim_crm_user_area_id,
+            unioned_targets.dim_crm_opp_owner_area_stamped_id
+        ) as dim_crm_user_area_id,
+        unioned_targets.dim_crm_user_hierarchy_stamped_id,
+        unioned_targets.dim_crm_opp_owner_sales_segment_stamped_id,
+        unioned_targets.dim_crm_opp_owner_geo_stamped_id,
+        unioned_targets.dim_crm_opp_owner_region_stamped_id,
+        unioned_targets.dim_crm_opp_owner_area_stamped_id,
+        sum(unioned_targets.allocated_target) as allocated_target
+
+    from unioned_targets
+    left join
+        sfdc_user_hierarchy_live
+        on unioned_targets.dim_crm_user_hierarchy_stamped_id
+        = sfdc_user_hierarchy_live.dim_crm_user_hierarchy_live_id
+        {{ dbt_utils.group_by(n=19) }}
+
+)
+
+{{
+    dbt_audit(
+        cte_ref="final_targets",
+        created_by="@mcooperDD",
+        updated_by="@michellecooper",
+        created_date="2020-12-18",
+        updated_date="2022-03-07",
+    )
+}}

--- a/tests/data/unformatted/213_gitlab_fct_sales_funnel_target.sql
+++ b/tests/data/unformatted/213_gitlab_fct_sales_funnel_target.sql
@@ -189,36 +189,30 @@ target_matrix as (
     from {{ ref("sheetload_sales_funnel_targets_matrix_source") }}
     left join
         date
-        on
-        {{
+        on {{
             sales_funnel_text_slugify(
                 "sheetload_sales_funnel_targets_matrix_source.month"
             )
-        }}
-        = {{ sales_funnel_text_slugify("date.fiscal_month_name_fy") }}
+        }} = {{ sales_funnel_text_slugify("date.fiscal_month_name_fy") }}
     left join
         sales_qualified_source
-        on
-        {{
+        on {{
             sales_funnel_text_slugify(
                 "sheetload_sales_funnel_targets_matrix_source.opportunity_source"
             )
         }}
-        =
-        {{
+        = {{
             sales_funnel_text_slugify(
                 "sales_qualified_source.sales_qualified_source_name"
             )
         }}
     left join
         order_type
-        on
-        {{
+        on {{
             sales_funnel_text_slugify(
                 "sheetload_sales_funnel_targets_matrix_source.order_type"
             )
-        }}
-        = {{ sales_funnel_text_slugify("order_type.order_type_name") }}
+        }} = {{ sales_funnel_text_slugify("order_type.order_type_name") }}
 
 ),
 fy22_user_hierarchy as (

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -42,6 +42,7 @@ from tests.util import check_formatting, read_test_data
         "unformatted/210_gitlab_gdpr_delete.sql",
         "unformatted/211_http_2019_cdn_17_20.sql",
         "unformatted/212_http_2019_cms_14_02.sql",
+        "unformatted/213_gitlab_fct_sales_funnel_target.sql",
         "unformatted/300_jinjafmt.sql",
     ],
 )


### PR DESCRIPTION
This PR solves the instability described in #175 by making two changes:
- fix: removing caching of node, line, comment props, which can cause issues when objects are mutated by jinjaformatter
- fix #175: add extra split before multiline jinja nodes

It also improves the style where singleton operators and multiline jinja nodes interact:
- fix: allow more merging of multiline jinja nodes
