### PR TITLE
Feature: Detect unsupported SQL commands and abort formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Formatting Changes + Bug Fixes
 
+-   DDL and DML statements (`create`, `insert`, `grant`, etc.) will no longer be formatted ([#243](https://github.com/tconbeer/sqlfmt/issues/243)). 
+    These statements were never supported by sqlfmt, and the existing algorithm produced bad formatting. Support for DDL and DML statements will be gradually added back in in future versions.
+    For more information, see the [tracking issue for DDL support](https://github.com/tconbeer/sqlfmt/issues/262).
 -   BigQuery typed array literals like `array<float64>[1, 2]` are now supported, and spaces will no longer be inserted around `<` and `>` ([#212](https://github.com/tconbeer/sqlfmt/issues/212))
 -   SparkSQL-specific keywords `tablesample`, `cluster by`, `distribute by`, `sort by`, and `lateral view` are now supported by the polyglot dialect ([#264](https://github.com/tconbeer/sqlfmt/issues/264))
 -   `pivot` and `unpivot` are now supported as word operators, and will have a space between the keyword and the following parentheses

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -358,6 +358,8 @@ class Polyglot(Dialect):
                         (
                             r"select(\s+(as\s+struct|as\s+value))?"
                             r"(\s+(all|top\s+\d+|distinct))?"
+                            # select into is ddl that needs additional handling
+                            r"(?!\s+into)"
                         ),
                         r"from",
                         (
@@ -420,6 +422,64 @@ class Polyglot(Dialect):
                     action=partial(
                         actions.add_node_to_buffer, token_type=TokenType.NAME
                     ),
+                ),
+                Rule(
+                    name="unsupported_ddl",
+                    priority=4000,
+                    pattern=group(
+                        group(
+                            r"alter",
+                            r"attach\s+rls\s+policy",
+                            r"cache\s+table",
+                            r"clear\s+cache",
+                            r"cluster",
+                            r"comment",
+                            r"copy",
+                            r"create",
+                            r"deallocate",
+                            r"declare",
+                            r"describe",
+                            r"desc\s+datashare",
+                            r"desc\s+identity\s+provider",
+                            r"delete",
+                            r"detach\s+rls\s+policy",
+                            r"discard",
+                            r"do",
+                            r"drop",
+                            r"execute",
+                            r"explain",
+                            r"export",
+                            r"fetch",
+                            r"get",
+                            r"grant",
+                            r"handler",
+                            r"import\s+foreign\s+schema",
+                            r"import\s+table",
+                            r"insert",
+                            r"list",
+                            r"lock",
+                            r"merge",
+                            r"move",
+                            # prepare transaction statements are simple enough
+                            # so we'll allow them
+                            r"prepare(?!\s+transaction)",
+                            r"put",
+                            r"reassign\s+owned",
+                            r"remove",
+                            r"rename\s+table",
+                            r"repair",
+                            r"revoke",
+                            r"security\s+label",
+                            r"select\s+into",
+                            r"truncate",
+                            r"unload",
+                            r"update",
+                            r"validate",
+                        )
+                        + r"\b[^;]*"
+                    )
+                    + group(r";", r"$"),
+                    action=actions.handle_possible_unsupported_sql,
                 ),
                 Rule(
                     name="name",

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -479,7 +479,7 @@ class Polyglot(Dialect):
                         + r"\b[^;]*"
                     )
                     + group(r";", r"$"),
-                    action=actions.handle_possible_unsupported_sql,
+                    action=actions.handle_possible_unsupported_ddl,
                 ),
                 Rule(
                     name="name",

--- a/src/sqlfmt/dialect.py
+++ b/src/sqlfmt/dialect.py
@@ -456,7 +456,12 @@ class Polyglot(Dialect):
                             r"handler",
                             r"import\s+foreign\s+schema",
                             r"import\s+table",
-                            r"insert",
+                            # snowflake: "insert into" or "insert overwrite into"
+                            # snowflake: has insert() function
+                            # spark: "insert overwrite" without the trailing "into"
+                            # redshift/pg: "insert into" only
+                            # bigquery: bare "insert" is okay
+                            r"insert(\s+overwrite)?(\s+into)?(?!\()",
                             r"list",
                             r"lock",
                             r"merge",

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,10 +30,10 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="1bd9940",  # sqlfmt 862f9a6
+            git_ref="e3d43b4",  # sqlfmt b21ea88
             expected_changed=4,
-            expected_unchanged=2413,
-            expected_errored=0,
+            expected_unchanged=2409,
+            expected_errored=4,
             sub_directory=Path("transform/snowflake-dbt/"),
         ),
         SQLProject(
@@ -48,7 +48,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="f3275ab",  # sqlfmt 862f9a6
+            git_ref="68b9a93",  # sqlfmt 9b7da04
             expected_changed=0,
             expected_unchanged=1702,
             expected_errored=0,

--- a/tests/data/preformatted/400_create_table.sql
+++ b/tests/data/preformatted/400_create_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE films (
+    code        char(5) CONSTRAINT firstkey PRIMARY KEY,
+    title       varchar(40) NOT NULL,
+    did         integer NOT NULL,
+    date_prod   date,
+    kind        varchar(10),
+    len         interval hour to minute
+);

--- a/tests/data/unformatted/400_create_fn_and_select.sql
+++ b/tests/data/unformatted/400_create_fn_and_select.sql
@@ -1,0 +1,90 @@
+# COPYRIGHT HTTP ARCHIVE
+# LICENSED UNDER APACHE 2.0
+# SEE: 
+# https://github.com/tconbeer/http_archive_almanac/blob/a57e75a9d37e150cb7963b821d9a33ad3d651571/LICENSE
+# standardSQL
+# 02_37: Distribution of unique z-index values per page
+create temporary function getzindexvalues(css string)
+returns array
+< string
+> language js
+as '''
+try {
+  var reduceValues = (values, rule) => {
+    if ('rules' in rule) {
+      return rule.rules.reduce(reduceValues, values);
+    }
+    if (!('declarations' in rule)) {
+      return values;
+    }
+
+    return values.concat(rule.declarations.filter(d => d.property.toLowerCase() == 'z-index' && !isNaN(parseInt(d.value))).map(d => parseInt(d.value)));
+  };
+  var $ = JSON.parse(css);
+  return $.stylesheet.rules.reduce(reduceValues, []);
+} catch (e) {
+  return [];
+}
+'''
+;
+
+SELECT
+    client, approx_quantiles(zindices, 1000)[offset(100)] as p10,
+    approx_quantiles(zindices, 1000)[offset(250)] as p25, approx_quantiles(zindices, 1000)[offset(500)] as p50,
+    approx_quantiles(zindices, 1000)[offset(750)] as p75, approx_quantiles(zindices, 1000)[offset(900)] as p90
+FROM
+    (
+        select client, count(distinct value) as zindices
+        from `httparchive.almanac.parsed_css`
+        left join unnest(getzindexvalues(css)) as value
+        where date = '2019-07-01'
+        group by client, page
+    )
+GROUP BY client
+)))))__SQLFMT_OUTPUT__(((((
+# COPYRIGHT HTTP ARCHIVE
+# LICENSED UNDER APACHE 2.0
+# SEE: 
+# https://github.com/tconbeer/http_archive_almanac/blob/a57e75a9d37e150cb7963b821d9a33ad3d651571/LICENSE
+# standardSQL
+# 02_37: Distribution of unique z-index values per page
+create temporary function getzindexvalues(css string)
+returns array
+< string
+> language js
+as '''
+try {
+  var reduceValues = (values, rule) => {
+    if ('rules' in rule) {
+      return rule.rules.reduce(reduceValues, values);
+    }
+    if (!('declarations' in rule)) {
+      return values;
+    }
+
+    return values.concat(rule.declarations.filter(d => d.property.toLowerCase() == 'z-index' && !isNaN(parseInt(d.value))).map(d => parseInt(d.value)));
+  };
+  var $ = JSON.parse(css);
+  return $.stylesheet.rules.reduce(reduceValues, []);
+} catch (e) {
+  return [];
+}
+'''
+;
+
+select
+    client,
+    approx_quantiles(zindices, 1000)[offset(100)] as p10,
+    approx_quantiles(zindices, 1000)[offset(250)] as p25,
+    approx_quantiles(zindices, 1000)[offset(500)] as p50,
+    approx_quantiles(zindices, 1000)[offset(750)] as p75,
+    approx_quantiles(zindices, 1000)[offset(900)] as p90
+from
+    (
+        select client, count(distinct value) as zindices
+        from `httparchive.almanac.parsed_css`
+        left join unnest(getzindexvalues(css)) as value
+        where date = '2019-07-01'
+        group by client, page
+    )
+group by client

--- a/tests/functional_tests/test_end_to_end.py
+++ b/tests/functional_tests/test_end_to_end.py
@@ -75,7 +75,7 @@ def test_end_to_end_preformatted(
     result = sqlfmt_runner.invoke(sqlfmt_main, args=args)
 
     assert result
-    assert "6 files" in result.stderr
+    assert "7 files" in result.stderr
 
     if "check" in options or "diff" in options:
         assert "passed formatting check" in result.stderr

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -13,6 +13,7 @@ from tests.util import check_formatting, read_test_data
         "preformatted/003_literals.sql",
         "preformatted/004_with_select.sql",
         "preformatted/301_multiline_jinjafmt.sql",
+        "preformatted/400_create_table.sql",
         "unformatted/100_select_case.sql",
         "unformatted/101_multiline.sql",
         "unformatted/102_lots_of_comments.sql",

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -53,6 +53,7 @@ from tests.util import check_formatting, read_test_data
         "unformatted/212_http_2019_cms_14_02.sql",
         "unformatted/213_gitlab_fct_sales_funnel_target.sql",
         "unformatted/300_jinjafmt.sql",
+        "unformatted/400_create_fn_and_select.sql",
     ],
 )
 def test_formatting(p: str) -> None:

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -195,6 +195,11 @@ class TestAllDialects:
             ("main", "unsupported_ddl", "select\ninto"),
             ("main", "unsupported_ddl", "insert"),
             ("main", "unsupported_ddl", "update"),
+            (
+                "main",
+                "unsupported_ddl",
+                "create function foo() returns int language javascript as $$foo;$$",
+            ),
             ("main", "name", "my_table_45"),
             ("main", "name", "replace"),
             ("main", "other_identifiers", "$2"),

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -201,7 +201,11 @@ class TestAllDialects:
             (
                 "main",
                 "unsupported_ddl",
-                "create function foo() returns int language javascript as $$foo;$$",
+                (
+                    "create function foo()\n"
+                    "--fn comment; another comment;\n"
+                    "returns int language javascript as $$foo;$$"
+                ),
             ),
             ("main", "name", "my_table_45"),
             ("main", "name", "replace"),

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -191,6 +191,10 @@ class TestAllDialects:
             ("main", "set_operator", "minus"),
             ("main", "set_operator", "except"),
             ("main", "bq_typed_array", "array<INT64>"),
+            ("main", "unsupported_ddl", "create table"),
+            ("main", "unsupported_ddl", "select\ninto"),
+            ("main", "unsupported_ddl", "insert"),
+            ("main", "unsupported_ddl", "update"),
             ("main", "name", "my_table_45"),
             ("main", "name", "replace"),
             ("main", "other_identifiers", "$2"),
@@ -265,6 +269,7 @@ class TestAllDialects:
             ("main", "operator", "."),
             ("main", "unterm_keyword", "lateral flatten"),
             ("main", "unterm_keyword", "for"),
+            ("main", "unterm_keyword", "select into"),
             ("main", "star_replace_exclude", "replace"),
             ("main", "unterm_keyword", "selection"),
             (

--- a/tests/unit_tests/test_dialect.py
+++ b/tests/unit_tests/test_dialect.py
@@ -194,6 +194,9 @@ class TestAllDialects:
             ("main", "unsupported_ddl", "create table"),
             ("main", "unsupported_ddl", "select\ninto"),
             ("main", "unsupported_ddl", "insert"),
+            ("main", "unsupported_ddl", "insert into"),
+            ("main", "unsupported_ddl", "insert overwrite"),
+            ("main", "unsupported_ddl", "insert overwrite into"),
             ("main", "unsupported_ddl", "update"),
             (
                 "main",
@@ -277,6 +280,7 @@ class TestAllDialects:
             ("main", "unterm_keyword", "select into"),
             ("main", "star_replace_exclude", "replace"),
             ("main", "unterm_keyword", "selection"),
+            ("main", "unsupported_ddl", "insert('abc', 1, 2, 'Z')"),
             (
                 "main",
                 "bq_typed_array",


### PR DESCRIPTION
This closes #243

We parse all known DDL/DML keywords as DATA tokens if they appear at depth 0 (e.g., not as an alias inside of a select statement).

This creates one known issue where unsupported SQL interacts with jinja in complex ways, but I think it's better than just blindly charging ahead and formatting DDL we don't understand.

- feat: lex unsupported ddl as DATA token so we don't format it
- fix: fix depth calc in handle_unsupported_ddl
- fix: parse semicolons in quotes as part of unsupported ddl token
- fix: insert ddl should not match snowflake insert() fn
- fix: allow sql comments in ddl
- chore: update changelog, primer
