### PR TITLE
Do not add trailing whitespace to empty comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
 
 -   sqlfmt now supports `{% materialization ... %}` and `{% call statement(...) %}` blocks ([#309](https://github.com/tconbeer/sqlfmt/issues/309)).
 -   sqlfmt now resets the SQL depth of a query after encountering an `{% endmacro %}`, `{% endtest %}`, `{% endcall %}`, or `{% endmaterialization %}` tag.
--   sqlfmt now supports `create warehouse` and `alter warehouse` statements ([#312](https://github.com/tconbeer/sqlfmt/issues/312), [#299](https://github.com/tconbeer/sqlfmt/issues/312))
--   sqlfmt now supports `alter function` and `drop function` statements ([#310](https://github.com/tconbeer/sqlfmt/issues/310), [#311](https://github.com/tconbeer/sqlfmt/issues/311)), and Snowflake's `create external function` statements ([#322](https://github.com/tconbeer/sqlfmt/issues/322))
+-   sqlfmt now supports `create warehouse` and `alter warehouse` statements ([#312](https://github.com/tconbeer/sqlfmt/issues/312), [#299](https://github.com/tconbeer/sqlfmt/issues/312)).
+-   sqlfmt now supports `alter function` and `drop function` statements ([#310](https://github.com/tconbeer/sqlfmt/issues/310), [#311](https://github.com/tconbeer/sqlfmt/issues/311)), and Snowflake's `create external function` statements ([#322](https://github.com/tconbeer/sqlfmt/issues/322)).
+-   fixed a bug where we added extra whitespace to the end of empty comment lines ([#319](https://github.com/tconbeer/sqlfmt/issues/319) - thank you [@eherde](https://github.com/eherde)!).
 -   fixed a bug where we could have unsafely run *black* against jinja that contained Python keywords and their safe alternatives (e.g., `return(return_())`).
 
 ## [0.13.0] - 2022-11-01

--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -18,20 +18,19 @@ class Comment:
     comment_marker: ClassVar[re.Pattern] = re.compile(r"(--|#|/\*|\{#-?)([^\S\n]*)")
 
     def __str__(self) -> str:
-        return self._calc_str
-
-    @property
-    def _calc_str(self) -> str:
         """
         Returns the contents of the comment token plus a trailing newline,
         without preceding whitespace, with a single space between the marker
         and the comment text.
         """
         if self.is_multiline:
-            return self.token.token + "\n"
+            return f"{self.token.token}\n"
         else:
             marker, comment_text = self._comment_parts()
-            return marker + " " + comment_text + "\n"
+            if comment_text:
+                return f"{marker} {comment_text}\n"
+            else:
+                return f"{marker}\n"
 
     def __len__(self) -> int:
         return len(str(self))

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,7 +30,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="ce9df96",  # sqlfmt b065a8b
+            git_ref="b53ed29",  # sqlfmt 6aa20a1
             expected_changed=4,
             expected_unchanged=2413,
             expected_errored=0,
@@ -48,7 +48,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="f3281d0",  # sqlfmt 26716b4
+            git_ref="ec18b52",  # sqlfmt 6aa20a1
             expected_changed=0,
             expected_unchanged=1702,
             expected_errored=0,

--- a/tests/data/unformatted/102_lots_of_comments.sql
+++ b/tests/data/unformatted/102_lots_of_comments.sql
@@ -29,7 +29,14 @@ select -- not distinct
     another_thing_entirely,
     yet_another_field
     -- another standalone comment
-from a_really_long_table -- with a super long comment that won't fit here and needs to move up
+from a_really_long_table; -- with a super long comment that won't fit here and needs to move up
+
+-- sometimes we like really long comments
+-- that wrap to many lines. And may even
+-- be a paragraph!
+--
+-- some people like blank lines between paragraphs of comments.
+select 1
 )))))__SQLFMT_OUTPUT__(((((
 with
     one as (select 1),  -- short
@@ -56,3 +63,11 @@ select  -- not distinct
 -- another standalone comment
 -- with a super long comment that won't fit here and needs to move up
 from a_really_long_table
+;
+
+-- sometimes we like really long comments
+-- that wrap to many lines. And may even
+-- be a paragraph!
+--
+-- some people like blank lines between paragraphs of comments.
+select 1

--- a/tests/unit_tests/test_comment.py
+++ b/tests/unit_tests/test_comment.py
@@ -116,3 +116,9 @@ def test_render_standalone(short_comment: Comment, prefix: str) -> None:
 def test_split_before(text: str, expected_splits: List[str]) -> None:
     result = list(Comment._split_before(text, max_length=10))
     assert result == expected_splits
+
+
+def test_empty_comment() -> None:
+    t = Token(type=TokenType.COMMENT, prefix=" ", token="-- ", spos=0, epos=3)
+    comment = Comment(t, is_standalone=True)
+    assert str(comment) == "--\n"


### PR DESCRIPTION
- fix #319: no trailing whitespace on empty comments
- chore: update primer refs
