### PR TITLE
Perf: Refactor Enum comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - sqlfmt now supports `is [not] distinct from` as a word operator ([#327](https://github.com/tconbeer/sqlfmt/issues/327) - thank you [@IgnorantWalking](https://github.com/IgnorantWalking), [@kadekillary](https://github.com/kadekillary)!)
 
+### Performance
+
+- sqlfmt runs finish in 20% less time due to algorithmic improvements
+
 ## [0.14.0] - 2022-11-30
 
 ### Formatting Changes + Bug Fixes

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,14 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports-cached-property"
+version = "1.0.2"
+description = "cached_property() - computed once per instance, cached as attribute"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[[package]]
 name = "black"
 version = "22.10.0"
 description = "The uncompromising code formatter."
@@ -87,7 +95,7 @@ python-versions = "*"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.1"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -98,15 +106,15 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.8.0"
+version = "3.8.1"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+testing = ["covdefaults (>=2.2.2)", "coverage (>=6.5)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -124,11 +132,11 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "gitdb"
-version = "4.0.9"
+version = "4.0.10"
 description = "Git Object Database"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 smmap = ">=3.0.1,<6"
@@ -147,7 +155,7 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""
 
 [[package]]
 name = "identify"
-version = "2.5.8"
+version = "2.5.9"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -254,7 +262,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = true
@@ -377,7 +385,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "setuptools"
-version = "65.5.1"
+version = "65.6.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -484,7 +492,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 
 [[package]]
 name = "zipp"
-version = "3.10.0"
+version = "3.11.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -501,12 +509,16 @@ sqlfmt-primer = ["gitpython"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "fce6ad85c06499e50a67f905b48e22ad86fce0a45714d19c17d298c3f9966780"
+content-hash = "1d6302c9b6327f936140943f7b6b2307ca54d83d3e4f7715905ca00648aa72fe"
 
 [metadata.files]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+backports-cached-property = [
+    {file = "backports.cached-property-1.0.2.tar.gz", hash = "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd"},
+    {file = "backports.cached_property-1.0.2-py3-none-any.whl", hash = "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"},
 ]
 black = [
     {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
@@ -600,28 +612,28 @@ distlib = [
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.1-py3-none-any.whl", hash = "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a"},
-    {file = "exceptiongroup-1.0.1.tar.gz", hash = "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 filelock = [
-    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
-    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
+    {file = "filelock-3.8.1-py3-none-any.whl", hash = "sha256:3156639b1454b5f828255abf5710f7fc1e10dac69bde3e09e6189b29a91f2505"},
+    {file = "filelock-3.8.1.tar.gz", hash = "sha256:9255d3cd8de8fcb2a441444f7a4f1949ae826da36cd070dc3e0c883614b4bbad"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
 gitdb = [
-    {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
-    {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
+    {file = "gitdb-4.0.10-py3-none-any.whl", hash = "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"},
+    {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
 ]
 gitpython = [
     {file = "GitPython-3.1.29-py3-none-any.whl", hash = "sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f"},
     {file = "GitPython-3.1.29.tar.gz", hash = "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"},
 ]
 identify = [
-    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
-    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
+    {file = "identify-2.5.9-py2.py3-none-any.whl", hash = "sha256:a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d"},
+    {file = "identify-2.5.9.tar.gz", hash = "sha256:906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
@@ -684,8 +696,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
-    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
-    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+    {file = "pathspec-0.10.2-py3-none-any.whl", hash = "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5"},
+    {file = "pathspec-0.10.2.tar.gz", hash = "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.4-py3-none-any.whl", hash = "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"},
@@ -762,8 +774,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 setuptools = [
-    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
-    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
+    {file = "setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
+    {file = "setuptools-65.6.3.tar.gz", hash = "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"},
 ]
 smmap = [
     {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
@@ -833,6 +845,6 @@ virtualenv = [
     {file = "virtualenv-20.16.2.tar.gz", hash = "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db"},
 ]
 zipp = [
-    {file = "zipp-3.10.0-py3-none-any.whl", hash = "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1"},
-    {file = "zipp-3.10.0.tar.gz", hash = "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"},
+    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
+    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python = "^3.7"
 click = "^8.0"
 tqdm = "^4.0"
 platformdirs = "^2.4.0"
-backports.cached_property = { version = "^1.0.2", python = "<3.8" }
+"backports.cached_property" = { version = "^1.0.2", python = "<3.8" }
 importlib_metadata = { version = "*", python = "<3.8" }
 tomli = { version = "^2.0.1", python = "<3.11" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ python = "^3.7"
 click = "^8.0"
 tqdm = "^4.0"
 platformdirs = "^2.4.0"
+backports.cached_property = { version = "^1.0.2", python = "<3.8" }
 importlib_metadata = { version = "*", python = "<3.8" }
 tomli = { version = "^2.0.1", python = "<3.11" }
 

--- a/src/sqlfmt/actions.py
+++ b/src/sqlfmt/actions.py
@@ -251,7 +251,7 @@ def handle_set_operator(
     if (
         token.token.lower() == "except"
         and prev_token
-        and prev_token.type == TokenType.STAR
+        and prev_token.type is TokenType.STAR
     ):
         token = Token(
             type=TokenType.WORD_OPERATOR,

--- a/src/sqlfmt/jinjafmt.py
+++ b/src/sqlfmt/jinjafmt.py
@@ -356,7 +356,7 @@ class JinjaFormatter:
                 is_blackened = self._format_jinja_node(
                     node, max_length=line_length - running_length
                 )
-                if i > 0 and is_blackened and node.is_multiline:
+                if i > 0 and is_blackened and node.is_multiline_jinja:
                     # if black turned a single-line jinja expression
                     # into a multiline one, we need to split before
                     # this node (since on the first pass the splitter

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -223,14 +223,6 @@ class Line:
         return any([n.is_jinja for n in self.nodes])
 
     @property
-    def contains_multiline_node(self) -> bool:
-        return any([n.is_multiline for n in self.nodes])
-
-    @property
-    def is_standalone_multiline_node(self) -> bool:
-        return self._is_standalone_if(self.contains_multiline_node)
-
-    @property
     def is_standalone_jinja_statement(self) -> bool:
         return self._is_standalone_if(self.starts_with_jinja_statement)
 

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -20,10 +20,6 @@ class Line:
     formatting_disabled: List[Token] = field(default_factory=list)
 
     def __str__(self) -> str:
-        return self._calc_str
-
-    @property
-    def _calc_str(self) -> str:
         """
         A Line is printed in one of three ways:
         1. Blank lines are just bare newlines, with no other whitespace

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -62,28 +62,28 @@ class LineMerger:
         nodes: List[Node] = []
         comments: List[Comment] = []
         final_newline: Optional[Node] = None
-        allow_multiline = True
+        allow_multiline_jinja = True
         for line in lines:
             # skip over newline nodes
             content_nodes = [
-                cls._raise_unmergeable(node, allow_multiline)
+                cls._raise_unmergeable(node, allow_multiline_jinja)
                 for node in line.nodes
                 if not node.is_newline
             ]
             if content_nodes:
                 final_newline = line.nodes[-1]
                 nodes.extend(content_nodes)
-                # we can merge lines containing multiline nodes iff:
+                # we can merge lines containing multiline jinja nodes iff:
                 # 1. the multiline node is on the first line (allow_multiline
                 #    is initialized to True)
                 # 2. the multiline node is on the second line and follows a
                 #    standalone operator
                 if not (
-                    allow_multiline
+                    allow_multiline_jinja
                     and len(content_nodes) == 1
                     and content_nodes[0].is_operator
                 ):
-                    allow_multiline = False
+                    allow_multiline_jinja = False
             comments.extend(line.comments)
 
         if not nodes or not final_newline:
@@ -94,7 +94,7 @@ class LineMerger:
         return nodes, comments
 
     @staticmethod
-    def _raise_unmergeable(node: Node, allow_multiline: bool) -> Node:
+    def _raise_unmergeable(node: Node, allow_multiline_jinja: bool) -> Node:
         """
         Raises a CannotMergeException if the node cannot be merged. Otherwise
         returns the node
@@ -107,7 +107,7 @@ class LineMerger:
             raise CannotMergeException(
                 "Can't merge multiple queries onto a single line"
             )
-        elif node.is_multiline and not allow_multiline:
+        elif node.is_multiline_jinja and not allow_multiline_jinja:
             raise CannotMergeException("Can't merge lines containing multiline nodes")
         else:
             return node

--- a/src/sqlfmt/node.py
+++ b/src/sqlfmt/node.py
@@ -53,7 +53,7 @@ class Node:
         """
         Returns the formatted text of this Node
         """
-        return self.prefix + self.value
+        return f"{self.prefix}{self.value}"
 
     def __repr__(self) -> str:
         """

--- a/src/sqlfmt/node.py
+++ b/src/sqlfmt/node.py
@@ -108,23 +108,12 @@ class Node:
         return self.token.type is TokenType.COMMA
 
     @property
-    def is_semicolon(self) -> bool:
-        return self.token.type is TokenType.SEMICOLON
-
-    @property
-    def is_set_operator(self) -> bool:
-        return self.token.type is TokenType.SET_OPERATOR
-
-    @property
     def divides_queries(self) -> bool:
-        return self.is_semicolon or self.is_set_operator
+        return self.token.type.divides_queries
 
     @property
     def is_opening_bracket(self) -> bool:
-        return self.token.type in (
-            TokenType.BRACKET_OPEN,
-            TokenType.STATEMENT_START,
-        )
+        return self.token.type.is_opening_bracket
 
     @property
     def is_bracket_operator(self) -> bool:

--- a/src/sqlfmt/node.py
+++ b/src/sqlfmt/node.py
@@ -12,13 +12,7 @@ def get_previous_token(prev_node: Optional["Node"]) -> Tuple[Optional[Token], bo
     if not prev_node:
         return None, False
     t = prev_node.token
-    if t.type in (
-        TokenType.NEWLINE,
-        TokenType.JINJA_STATEMENT,
-        TokenType.JINJA_BLOCK_START,
-        TokenType.JINJA_BLOCK_END,
-        TokenType.JINJA_BLOCK_KEYWORD,
-    ):
+    if t.type.does_not_set_prev_sql_context:
         prev, _ = get_previous_token(prev_node.previous_node)
         return prev, True
     else:
@@ -107,19 +101,19 @@ class Node:
         """
         True for Nodes representing unterminated SQL keywords, like select, from, where
         """
-        return self.token.type == TokenType.UNTERM_KEYWORD
+        return self.token.type is TokenType.UNTERM_KEYWORD
 
     @property
     def is_comma(self) -> bool:
-        return self.token.type == TokenType.COMMA
+        return self.token.type is TokenType.COMMA
 
     @property
     def is_semicolon(self) -> bool:
-        return self.token.type == TokenType.SEMICOLON
+        return self.token.type is TokenType.SEMICOLON
 
     @property
     def is_set_operator(self) -> bool:
-        return self.token.type == TokenType.SET_OPERATOR
+        return self.token.type is TokenType.SET_OPERATOR
 
     @property
     def divides_queries(self) -> bool:
@@ -141,7 +135,7 @@ class Node:
         Alternatively, node is an open paren ("(")
         that follow an closing angle bracket.
         """
-        if self.token.type != TokenType.BRACKET_OPEN:
+        if self.token.type is not TokenType.BRACKET_OPEN:
             return False
 
         prev_token, _ = get_previous_token(self.previous_node)
@@ -158,7 +152,7 @@ class Node:
         else:
             return (
                 self.value == "("
-                and prev_token.type == TokenType.BRACKET_CLOSE
+                and prev_token.type is TokenType.BRACKET_CLOSE
                 and ">" in prev_token.token
             )
 
@@ -178,50 +172,31 @@ class Node:
 
     @property
     def is_jinja(self) -> bool:
-        return self.token.type in (
-            TokenType.JINJA_EXPRESSION,
-            TokenType.JINJA_STATEMENT,
-            TokenType.JINJA_BLOCK_START,
-            TokenType.JINJA_BLOCK_KEYWORD,
-            TokenType.JINJA_BLOCK_END,
-        )
+        return self.token.type.is_jinja
 
     @property
     def is_closing_jinja_block(self) -> bool:
-        return self.token.type == TokenType.JINJA_BLOCK_END
+        return self.token.type is TokenType.JINJA_BLOCK_END
 
     @property
     def is_jinja_block_keyword(self) -> bool:
-        return self.token.type == TokenType.JINJA_BLOCK_KEYWORD
+        return self.token.type is TokenType.JINJA_BLOCK_KEYWORD
 
     @property
     def is_jinja_statement(self) -> bool:
-        return self.token.type in (
-            TokenType.JINJA_STATEMENT,
-            TokenType.JINJA_BLOCK_START,
-            TokenType.JINJA_BLOCK_KEYWORD,
-            TokenType.JINJA_BLOCK_END,
-        )
+        return self.token.type.is_jinja_statement
 
     @property
     def is_operator(self) -> bool:
         return (
-            self.token.type
-            in (
-                TokenType.OPERATOR,
-                TokenType.WORD_OPERATOR,
-                TokenType.ON,
-                TokenType.BOOLEAN_OPERATOR,
-                TokenType.DOUBLE_COLON,
-                TokenType.SEMICOLON,
-            )
+            self.token.type.is_always_operator
             or self.is_multiplication_star
             or self.is_bracket_operator
         )
 
     @property
     def is_boolean_operator(self) -> bool:
-        return self.token.type == TokenType.BOOLEAN_OPERATOR
+        return self.token.type is TokenType.BOOLEAN_OPERATOR
 
     @property
     def is_multiplication_star(self) -> bool:
@@ -230,7 +205,7 @@ class Node:
         the multiplication operator. Returns true iff this Node is a multiplication
         operator
         """
-        if self.token.type != TokenType.STAR:
+        if self.token.type is not TokenType.STAR:
             return False
         prev_token, _ = get_previous_token(self.previous_node)
         if not prev_token:
@@ -246,7 +221,7 @@ class Node:
         """
         True if this node is a WORD_OPERATOR with the value "between"
         """
-        return self.token.type == TokenType.WORD_OPERATOR and self.value == "between"
+        return self.token.type is TokenType.WORD_OPERATOR and self.value == "between"
 
     @property
     def has_preceding_between_operator(self) -> bool:
@@ -276,22 +251,11 @@ class Node:
 
     @property
     def is_newline(self) -> bool:
-        return self.token.type == TokenType.NEWLINE
+        return self.token.type is TokenType.NEWLINE
 
     @property
-    def is_multiline(self) -> bool:
-        if (
-            self.token.type
-            in (
-                TokenType.DATA,
-                TokenType.JINJA_EXPRESSION,
-                TokenType.JINJA_STATEMENT,
-                TokenType.JINJA_BLOCK_START,
-                TokenType.JINJA_BLOCK_END,
-                TokenType.JINJA_BLOCK_KEYWORD,
-            )
-            and "\n" in self.value
-        ):
+    def is_multiline_jinja(self) -> bool:
+        if self.token.type.is_jinja and "\n" in self.value:
             return True
         else:
             return False

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -39,7 +39,7 @@ class LineSplitter:
         if (
             # if there is a multiline node on this line and it isn't the
             # only thing on this line, then split before the multiline node
-            node.is_multiline
+            node.is_multiline_jinja
             # always split before any unterm kw
             or node.is_unterm_keyword
             # always split before any opening jinja block

--- a/src/sqlfmt/token.py
+++ b/src/sqlfmt/token.py
@@ -1,7 +1,12 @@
 import re
+import sys
 from enum import Enum, auto
-from functools import cached_property
 from typing import NamedTuple
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from backports.cached_property import cached_property
 
 
 class TokenType(Enum):

--- a/src/sqlfmt/token.py
+++ b/src/sqlfmt/token.py
@@ -56,6 +56,20 @@ class TokenType(Enum):
         return self.is_jinja_statement or self is TokenType.JINJA_EXPRESSION
 
     @cached_property
+    def is_opening_bracket(self) -> bool:
+        return self in [
+            TokenType.BRACKET_OPEN,
+            TokenType.STATEMENT_START,
+        ]
+
+    @cached_property
+    def divides_queries(self) -> bool:
+        return self in [
+            TokenType.SEMICOLON,
+            TokenType.SET_OPERATOR,
+        ]
+
+    @cached_property
     def does_not_set_prev_sql_context(self) -> bool:
         return self.is_jinja_statement or self is TokenType.NEWLINE
 

--- a/src/sqlfmt/token.py
+++ b/src/sqlfmt/token.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum, auto
+from functools import cached_property
 from typing import NamedTuple
 
 
@@ -40,6 +41,78 @@ class TokenType(Enum):
     UNTERM_KEYWORD = auto()  # Unterminated keyword
     SET_OPERATOR = auto()
     NAME = auto()
+
+    @cached_property
+    def is_jinja_statement(self) -> bool:
+        return self in (
+            TokenType.JINJA_STATEMENT,
+            TokenType.JINJA_BLOCK_START,
+            TokenType.JINJA_BLOCK_KEYWORD,
+            TokenType.JINJA_BLOCK_END,
+        )
+
+    @cached_property
+    def is_jinja(self) -> bool:
+        return self.is_jinja_statement or self is TokenType.JINJA_EXPRESSION
+
+    @cached_property
+    def does_not_set_prev_sql_context(self) -> bool:
+        return self.is_jinja_statement or self is TokenType.NEWLINE
+
+    @cached_property
+    def is_always_operator(self) -> bool:
+        return self in [
+            TokenType.OPERATOR,
+            TokenType.WORD_OPERATOR,
+            TokenType.ON,
+            TokenType.BOOLEAN_OPERATOR,
+            TokenType.DOUBLE_COLON,
+            TokenType.SEMICOLON,
+        ]
+
+    @cached_property
+    def is_never_preceded_by_space(self) -> bool:
+        return self in [
+            TokenType.BRACKET_CLOSE,
+            TokenType.COLON,
+            TokenType.DOUBLE_COLON,
+            TokenType.COMMA,
+            TokenType.DOT,
+            TokenType.NEWLINE,
+        ]
+
+    @cached_property
+    def is_preceded_by_space_except_after_open_bracket(self) -> bool:
+        return self in [
+            TokenType.UNTERM_KEYWORD,
+            TokenType.STATEMENT_START,
+            TokenType.STATEMENT_END,
+            TokenType.WORD_OPERATOR,
+            TokenType.BOOLEAN_OPERATOR,
+            TokenType.ON,
+        ]
+
+    @cached_property
+    def is_possible_name(self) -> bool:
+        return self in [
+            TokenType.QUOTED_NAME,
+            TokenType.NAME,
+            TokenType.STAR,
+            TokenType.JINJA_EXPRESSION,
+        ]
+
+    @cached_property
+    def is_always_lowercased(self) -> bool:
+        return self in [
+            TokenType.UNTERM_KEYWORD,
+            TokenType.BRACKET_OPEN,
+            TokenType.STATEMENT_START,
+            TokenType.STATEMENT_END,
+            TokenType.WORD_OPERATOR,
+            TokenType.ON,
+            TokenType.BOOLEAN_OPERATOR,
+            TokenType.SET_OPERATOR,
+        ]
 
 
 class Token(NamedTuple):

--- a/tests/unit_tests/test_actions.py
+++ b/tests/unit_tests/test_actions.py
@@ -58,7 +58,7 @@ def test_add_node_to_buffer(default_analyzer: Analyzer) -> None:
     assert len(default_analyzer.node_buffer) == 2
 
     node = default_analyzer.node_buffer[1]
-    assert node.token.type == TokenType.NAME
+    assert node.token.type is TokenType.NAME
 
     assert default_analyzer.pos == 8
 
@@ -83,7 +83,7 @@ def test_safe_add_node_to_buffer(default_analyzer: Analyzer) -> None:
     assert len(default_analyzer.node_buffer) == 1
 
     node = default_analyzer.node_buffer[0]
-    assert node.token.type == TokenType.NAME
+    assert node.token.type is TokenType.NAME
 
     assert default_analyzer.pos == 3
 
@@ -292,7 +292,7 @@ def test_handle_jinja_set_block(jinja_analyzer: Analyzer, source_string: str) ->
     assert jinja_analyzer.line_buffer == []
     assert jinja_analyzer.comment_buffer == []
     assert len(jinja_analyzer.node_buffer) == 1
-    assert jinja_analyzer.node_buffer[0].token.type == TokenType.DATA
+    assert jinja_analyzer.node_buffer[0].token.type is TokenType.DATA
 
 
 def test_handle_jinja_set_block_unterminated(jinja_analyzer: Analyzer) -> None:
@@ -332,14 +332,14 @@ def test_handle_jinja_if_block(jinja_analyzer: Analyzer) -> None:
         )
     assert len(jinja_analyzer.line_buffer) == 4
     assert (
-        jinja_analyzer.line_buffer[0].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+        jinja_analyzer.line_buffer[0].nodes[0].token.type is TokenType.JINJA_BLOCK_START
     )
     assert (
         jinja_analyzer.line_buffer[2].nodes[0].token.type
-        == TokenType.JINJA_BLOCK_KEYWORD
+        is TokenType.JINJA_BLOCK_KEYWORD
     )
     assert len(jinja_analyzer.node_buffer) == 1
-    assert jinja_analyzer.node_buffer[-1].token.type == TokenType.JINJA_BLOCK_END
+    assert jinja_analyzer.node_buffer[-1].token.type is TokenType.JINJA_BLOCK_END
 
 
 def test_handle_jinja_if_block_unterminated(jinja_analyzer: Analyzer) -> None:
@@ -390,24 +390,24 @@ def test_handle_jinja_if_block_nested(jinja_analyzer: Analyzer) -> None:
         )
     assert len(jinja_analyzer.line_buffer) == 8
     assert (
-        jinja_analyzer.line_buffer[0].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+        jinja_analyzer.line_buffer[0].nodes[0].token.type is TokenType.JINJA_BLOCK_START
     )
     assert (
-        jinja_analyzer.line_buffer[1].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+        jinja_analyzer.line_buffer[1].nodes[0].token.type is TokenType.JINJA_BLOCK_START
     )
     assert (
         jinja_analyzer.line_buffer[3].nodes[0].token.type
-        == TokenType.JINJA_BLOCK_KEYWORD
+        is TokenType.JINJA_BLOCK_KEYWORD
     )
     assert (
-        jinja_analyzer.line_buffer[5].nodes[0].token.type == TokenType.JINJA_BLOCK_END
+        jinja_analyzer.line_buffer[5].nodes[0].token.type is TokenType.JINJA_BLOCK_END
     )
     assert (
         jinja_analyzer.line_buffer[6].nodes[0].token.type
-        == TokenType.JINJA_BLOCK_KEYWORD
+        is TokenType.JINJA_BLOCK_KEYWORD
     )
     assert len(jinja_analyzer.node_buffer) == 1
-    assert jinja_analyzer.node_buffer[-1].token.type == TokenType.JINJA_BLOCK_END
+    assert jinja_analyzer.node_buffer[-1].token.type is TokenType.JINJA_BLOCK_END
 
 
 def test_handle_jinja_for_block(jinja_analyzer: Analyzer) -> None:
@@ -430,13 +430,13 @@ def test_handle_jinja_for_block(jinja_analyzer: Analyzer) -> None:
         start_rule.action(jinja_analyzer, source_string, match)
     assert len(jinja_analyzer.line_buffer) == 9
     assert (
-        jinja_analyzer.line_buffer[0].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+        jinja_analyzer.line_buffer[0].nodes[0].token.type is TokenType.JINJA_BLOCK_START
     )
     assert (
-        jinja_analyzer.line_buffer[1].nodes[0].token.type == TokenType.JINJA_STATEMENT
+        jinja_analyzer.line_buffer[1].nodes[0].token.type is TokenType.JINJA_STATEMENT
     )
     assert len(jinja_analyzer.node_buffer) == 1
-    assert jinja_analyzer.node_buffer[-1].token.type == TokenType.JINJA_BLOCK_END
+    assert jinja_analyzer.node_buffer[-1].token.type is TokenType.JINJA_BLOCK_END
 
 
 def test_handle_jinja_call_block(default_analyzer: Analyzer) -> None:
@@ -449,8 +449,8 @@ def test_handle_jinja_call_block(default_analyzer: Analyzer) -> None:
     """.strip()
     query = default_analyzer.parse_query(source_string=source_string.lstrip())
 
-    assert query.lines[1].nodes[0].token.type == TokenType.JINJA_BLOCK_START
-    assert query.lines[-2].nodes[0].token.type == TokenType.JINJA_BLOCK_END
+    assert query.lines[1].nodes[0].token.type is TokenType.JINJA_BLOCK_START
+    assert query.lines[-2].nodes[0].token.type is TokenType.JINJA_BLOCK_END
 
     # ensure endcall block resets sql depth
     outer_select = query.nodes[0]
@@ -468,13 +468,13 @@ def test_handle_unsupported_ddl(default_analyzer: Analyzer) -> None:
     assert len(query.lines) == 3
     first_create_line = query.lines[0]
     assert len(first_create_line.nodes) == 9
-    assert first_create_line.nodes[0].token.type == TokenType.FMT_OFF
-    assert first_create_line.nodes[-2].token.type == TokenType.SEMICOLON
+    assert first_create_line.nodes[0].token.type is TokenType.FMT_OFF
+    assert first_create_line.nodes[-2].token.type is TokenType.SEMICOLON
 
     select_line = query.lines[1]
     assert len(select_line.nodes) == 8
-    assert select_line.nodes[1].token.type == TokenType.NAME
-    assert select_line.nodes[3].token.type == TokenType.NAME
+    assert select_line.nodes[1].token.type is TokenType.NAME
+    assert select_line.nodes[3].token.type is TokenType.NAME
 
 
 def test_handle_explain(default_analyzer: Analyzer) -> None:
@@ -486,13 +486,13 @@ def test_handle_explain(default_analyzer: Analyzer) -> None:
     assert len(query.lines) == 2
     explain_line = query.lines[0]
     assert len(explain_line.nodes) == 5
-    assert explain_line.nodes[0].token.type == TokenType.UNTERM_KEYWORD
-    assert explain_line.nodes[1].token.type == TokenType.UNTERM_KEYWORD
+    assert explain_line.nodes[0].token.type is TokenType.UNTERM_KEYWORD
+    assert explain_line.nodes[1].token.type is TokenType.UNTERM_KEYWORD
 
     select_line = query.lines[1]
     assert len(select_line.nodes) == 8
-    assert select_line.nodes[0].token.type == TokenType.UNTERM_KEYWORD
-    assert select_line.nodes[1].token.type == TokenType.NAME
+    assert select_line.nodes[0].token.type is TokenType.UNTERM_KEYWORD
+    assert select_line.nodes[1].token.type is TokenType.NAME
 
 
 def test_handle_semicolon(default_analyzer: Analyzer) -> None:
@@ -534,7 +534,7 @@ def test_handle_ddl_as_quoted(function_analyzer: Analyzer) -> None:
     assert len(function_analyzer.node_buffer) == 3
     assert function_analyzer.node_buffer[0].is_unterm_keyword
     # ensure we're lexing using the create_fn rules (implying an empty rule stack)
-    assert function_analyzer.node_buffer[1].token.type == TokenType.QUOTED_NAME
+    assert function_analyzer.node_buffer[1].token.type is TokenType.QUOTED_NAME
     assert function_analyzer.rule_stack
     # ensure security definer is being lexed with the create_function ruleset (as a kw)
     assert function_analyzer.node_buffer[2].is_unterm_keyword
@@ -568,7 +568,7 @@ def test_handle_number_unary(default_analyzer: Analyzer) -> None:
         -1 + -2,
     """
     query = default_analyzer.parse_query(source_string=source_string.lstrip())
-    numbers = [str(n).strip() for n in query.nodes if n.token.type == TokenType.NUMBER]
+    numbers = [str(n).strip() for n in query.nodes if n.token.type is TokenType.NUMBER]
     assert numbers == ["+1", "-2", "-1", "-2"]
 
 
@@ -583,5 +583,5 @@ def test_handle_number_binary(default_analyzer: Analyzer) -> None:
         case when true then foo else bar end+2
     """
     query = default_analyzer.parse_query(source_string=source_string.lstrip())
-    numbers = [str(n).strip() for n in query.nodes if n.token.type == TokenType.NUMBER]
+    numbers = [str(n).strip() for n in query.nodes if n.token.type is TokenType.NUMBER]
     assert numbers == ["1", "1", "1", "1", "-1", "2", "2", "2", "2"]

--- a/tests/unit_tests/test_analyzer.py
+++ b/tests/unit_tests/test_analyzer.py
@@ -111,8 +111,8 @@ def test_case_statement_parsing(default_analyzer: Analyzer) -> None:
     assert computed_line_depths == expected_line_depths
 
     # there are 6 case statements in the test data
-    assert len([t for t in q.tokens if t.type == TokenType.STATEMENT_START]) == 6
-    assert len([t for t in q.tokens if t.type == TokenType.STATEMENT_END]) == 6
+    assert len([t for t in q.tokens if t.type is TokenType.STATEMENT_START]) == 6
+    assert len([t for t in q.tokens if t.type is TokenType.STATEMENT_END]) == 6
 
 
 def test_cte_parsing(default_analyzer: Analyzer) -> None:

--- a/tests/unit_tests/test_jinjafmt.py
+++ b/tests/unit_tests/test_jinjafmt.py
@@ -205,11 +205,11 @@ def test_format_line_single_to_multi(
     line = q.lines[0]
     j_node = line.nodes[1]
     assert j_node.is_jinja
-    assert not j_node.is_multiline
+    assert not j_node.is_multiline_jinja
 
     new_lines = jinja_formatter.format_line(line)
     assert len(new_lines) == 2  # make sure the linesplitter did its thing
-    assert j_node.is_multiline  # jinjafmt mutated this node to be multiline
+    assert j_node.is_multiline_jinja  # jinjafmt mutated this node to be multiline
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -67,13 +67,11 @@ def test_bare_line(bare_line: Line) -> None:
 
     assert not bare_line.starts_with_unterm_keyword
     assert not bare_line.contains_unterm_keyword
-    assert not bare_line.contains_multiline_node
     assert not bare_line.contains_operator
     assert not bare_line.starts_with_comma
     assert not bare_line.starts_with_bracket_operator
     assert not bare_line.starts_with_operator
     assert not bare_line.is_blank_line
-    assert not bare_line.is_standalone_multiline_node
     assert not bare_line.is_too_long(88)
     assert not bare_line.opens_new_bracket
     assert bare_line.open_brackets == []
@@ -116,15 +114,13 @@ def test_simple_line(
     assert not simple_line.starts_with_comma
     assert not simple_line.starts_with_bracket_operator
     assert not simple_line.starts_with_operator
-    assert not simple_line.contains_multiline_node
     assert not simple_line.is_blank_line
-    assert not simple_line.is_standalone_multiline_node
     assert not simple_line.is_standalone_comma
     assert not simple_line.is_too_long(88)
     assert not simple_line.opens_new_bracket
     assert not simple_line.previous_line_has_open_jinja_blocks_not_keywords
 
-    assert simple_line.nodes[5].token.type == TokenType.STAR
+    assert simple_line.nodes[5].token.type is TokenType.STAR
     assert not simple_line.nodes[5].is_multiplication_star
 
 
@@ -137,7 +133,7 @@ def test_bare_append_newline(bare_line: Line, node_manager: NodeManager) -> None
     assert bare_line.nodes
     assert bare_line.is_blank_line
     new_last_node = bare_line.nodes[-1]
-    assert new_last_node.token.type == TokenType.NEWLINE
+    assert new_last_node.token.type is TokenType.NEWLINE
     assert (new_last_node.token.spos, new_last_node.token.epos) == (0, 0)
 
 
@@ -166,14 +162,14 @@ def test_simple_append_newline(simple_line: Line, node_manager: NodeManager) -> 
 
     # this line already ends with a newline
     last_node = simple_line.nodes[-1]
-    assert last_node.token.type == TokenType.NEWLINE
+    assert last_node.token.type is TokenType.NEWLINE
     assert last_node.previous_node
-    assert last_node.previous_node.token.type != TokenType.NEWLINE
+    assert last_node.previous_node.token.type is not TokenType.NEWLINE
 
     node_manager.append_newline(simple_line)
     new_last_node = simple_line.nodes[-1]
     assert new_last_node != last_node
-    assert new_last_node.token.type == TokenType.NEWLINE
+    assert new_last_node.token.type is TokenType.NEWLINE
     assert new_last_node.previous_node == last_node
     assert new_last_node.previous_node.token == last_node.token
 
@@ -288,36 +284,6 @@ def test_long_comments_that_are_not_wrapped(
     simple_line.comments = [comment]
     expected_render = raw_comment + "\n" "with abc as (select * from my_table)\n"
     assert simple_line.render_with_comments(88) == expected_render
-
-
-def test_is_standalone_multiline_node(
-    bare_line: Line, simple_line: Line, node_manager: NodeManager
-) -> None:
-
-    assert not bare_line.is_standalone_multiline_node
-    assert not simple_line.is_standalone_multiline_node
-
-    multiline_t = Token(
-        type=TokenType.JINJA_EXPRESSION,
-        prefix="",
-        token="{{\nmy JINJA\n}}",
-        spos=0,
-        epos=16,
-    )
-
-    bare_line.nodes.append(node_manager.create_node(multiline_t, None))
-    simple_line.nodes.append(
-        node_manager.create_node(multiline_t, simple_line.nodes[-1])
-    )
-
-    assert bare_line.is_standalone_multiline_node
-    assert not simple_line.is_standalone_multiline_node
-
-    node_manager.append_newline(bare_line)
-    node_manager.append_newline(simple_line)
-
-    assert bare_line.is_standalone_multiline_node
-    assert not simple_line.is_standalone_multiline_node
 
 
 def test_is_standalone_jinja_statement(

--- a/tests/unit_tests/test_node.py
+++ b/tests/unit_tests/test_node.py
@@ -83,10 +83,10 @@ def test_is_the_and_after_the_between_operator(default_mode: Mode) -> None:
     ).parse_query(source_string=source_string)
 
     and_nodes = [
-        node for node in q.nodes if node.token.type == TokenType.BOOLEAN_OPERATOR
+        node for node in q.nodes if node.token.type is TokenType.BOOLEAN_OPERATOR
     ]
     other_nodes = [
-        node for node in q.nodes if node.token.type != TokenType.BOOLEAN_OPERATOR
+        node for node in q.nodes if node.token.type is not TokenType.BOOLEAN_OPERATOR
     ]
     boolean_ands = and_nodes[::2]
     between_ands = and_nodes[1::2]

--- a/tests/unit_tests/test_node_manager.py
+++ b/tests/unit_tests/test_node_manager.py
@@ -384,7 +384,7 @@ def test_disabled_formatting(default_mode: Mode) -> None:
     assert create_publication_line.formatting_disabled
     assert create_publication_line.nodes
     create_token = create_publication_line.nodes[0].token
-    assert create_token.type == TokenType.FMT_OFF
+    assert create_token.type is TokenType.FMT_OFF
     assert create_token in create_publication_line.nodes[0].formatting_disabled
     assert len(create_publication_line.nodes[0].formatting_disabled) == 3
     semicolon_node = create_publication_line.nodes[-2]


### PR DESCRIPTION
- refactor: replace enum list comparisons with cached property. 11% reduction in gitlab runtime
- refactor: more token type caching, further 8% reduction in runtime
- refactor: clean up line.__str__
