### PR TITLE
Support Nested Set and Call Blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes + Bug Fixes
+
+-   fixed a bug where nested `{% set %}` and `{% call %}` blocks would cause a parsing error ([#338](https://github.com/tconbeer/sqlfmt/issues/338) - thank you [@AndrewLane](https://github.com/AndrewLane)!).
+
 ## [0.14.1] - 2022-12-06
 
 ### Formatting Changes + Bug Fixes
 
 -   sqlfmt now supports `is [not] distinct from` as a word operator ([#327](https://github.com/tconbeer/sqlfmt/issues/327) - thank you [@IgnorantWalking](https://github.com/IgnorantWalking), [@kadekillary](https://github.com/kadekillary)!).
--   fixed a bug where jinja `{% call %}` blocks that called a macro that wasn't `statement` caused a parsing error ([#335](https://github.com/tconbeer/sqlfmt/issues/327) - thank you [@AndrewLane](https://github.com/AndrewLane)!).
+-   fixed a bug where jinja `{% call %}` blocks that called a macro that wasn't `statement` caused a parsing error ([#335](https://github.com/tconbeer/sqlfmt/issues/335) - thank you [@AndrewLane](https://github.com/AndrewLane)!).
 
 ### Performance
 

--- a/src/sqlfmt/actions.py
+++ b/src/sqlfmt/actions.py
@@ -360,7 +360,6 @@ def handle_jinja_block_keyword(
     analyzer: "Analyzer",
     source_string: str,
     match: re.Match,
-    start_rule_names: List[str],
 ) -> None:
     """
     Lex tags like {% elif ... %} and {% else %} that continue an open jinja block
@@ -400,7 +399,11 @@ def handle_jinja_data_block_start(
 ) -> None:
     """
     Lex tags like {% set foo %} and {% call my_macro %} that open a jinja block
-    that can contain arbitrary data
+    that can contain arbitrary data.
+
+    This can get called from the JINJA ruleset, in which case we need to
+    raise an additional StopRulesetLexing after the JINJA_DATA segment
+    is fully lexed.
     """
     add_node_to_buffer(
         analyzer=analyzer,
@@ -424,7 +427,6 @@ def handle_jinja_block_end(
     analyzer: "Analyzer",
     source_string: str,
     match: re.Match,
-    start_rule_names: List[str],
     reset_sql_depth: bool = False,
 ) -> None:
     """

--- a/src/sqlfmt/analyzer.py
+++ b/src/sqlfmt/analyzer.py
@@ -27,7 +27,6 @@ class Analyzer:
     comment_buffer: List[Comment] = field(default_factory=list)
     line_buffer: List[Line] = field(default_factory=list)
     rule_stack: List[List[Rule]] = field(default_factory=list)
-    stops: List[int] = field(default_factory=list)
     pos: int = 0
 
     @property
@@ -125,9 +124,6 @@ class Analyzer:
 
         Mutates the analyzer's buffers and pos
         """
-        if self.stops and self.pos >= self.stops[-1]:
-            raise StopIteration
-
         for rule in self.rules:
             match = rule.program.match(source_string, self.pos)
             if match:

--- a/src/sqlfmt/exception.py
+++ b/src/sqlfmt/exception.py
@@ -64,19 +64,10 @@ class InlineCommentException(SqlfmtControlFlowException):
     pass
 
 
-class StopJinjaLexing(SqlfmtControlFlowException):
-    """
-    Raised by the Analyzer or one of its actions to indicate
-    that further lexing should use the main ruleset
-    """
-
-    pass
-
-
 class StopRulesetLexing(SqlfmtControlFlowException):
     """
     Raised by the Analyzer or one of its actions to indicate
-    that further lexing should use the main ruleset
+    that further lexing should use the previous ruleset
     """
 
     pass

--- a/src/sqlfmt/rules/__init__.py
+++ b/src/sqlfmt/rules/__init__.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 from sqlfmt import actions
-from sqlfmt.exception import StopRulesetLexing
 from sqlfmt.rule import Rule
 from sqlfmt.rules.common import (
     ALTER_DROP_FUNCTION,
@@ -193,9 +192,7 @@ MAIN = [
         pattern=group(r"grant", r"revoke") + group(r"\W", r"$"),
         action=partial(
             actions.handle_nonreserved_keyword,
-            action=partial(
-                actions.lex_ruleset, new_ruleset=GRANT, stop_exception=StopRulesetLexing
-            ),
+            action=partial(actions.lex_ruleset, new_ruleset=GRANT),
         ),
     ),
     Rule(
@@ -207,7 +204,6 @@ MAIN = [
             action=partial(
                 actions.lex_ruleset,
                 new_ruleset=FUNCTION,
-                stop_exception=StopRulesetLexing,
             ),
         ),
     ),
@@ -224,7 +220,6 @@ MAIN = [
             action=partial(
                 actions.lex_ruleset,
                 new_ruleset=WAREHOUSE,
-                stop_exception=StopRulesetLexing,
             ),
         ),
     ),

--- a/src/sqlfmt/rules/core.py
+++ b/src/sqlfmt/rules/core.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 from sqlfmt import actions
-from sqlfmt.exception import StopJinjaLexing
 from sqlfmt.rule import Rule
 from sqlfmt.rules.common import EOL, NEWLINE, SQL_COMMENT, SQL_QUOTED_EXP, group
 from sqlfmt.rules.jinja import JINJA
@@ -27,9 +26,7 @@ CORE = [
         name="jinja_start",
         priority=120,
         pattern=group(r"\{[{%#]"),
-        action=partial(
-            actions.lex_ruleset, new_ruleset=JINJA, stop_exception=StopJinjaLexing
-        ),
+        action=partial(actions.lex_ruleset, new_ruleset=JINJA),
     ),
     # we should never match the end of a jinja tag by itself
     Rule(

--- a/src/sqlfmt/rules/jinja.py
+++ b/src/sqlfmt/rules/jinja.py
@@ -1,9 +1,74 @@
 from functools import partial
 
 from sqlfmt import actions
+from sqlfmt.exception import StopJinjaLexing
 from sqlfmt.rule import Rule
-from sqlfmt.rules.common import group
+from sqlfmt.rules.common import NEWLINE, group
 from sqlfmt.token import TokenType
+
+JINJA_SHARED_PATTERNS = {
+    "set": r"\{%-?\s*set\s+[^=]+?-?%\}",
+    "endset": r"\{%-?\s*endset\s*-?%\}",
+    "call": r"\{%-?\s*call\s+\w+.*?-?%\}",
+    "endcall": r"\{%-?\s*endcall\s*-?%\}",
+}
+
+JINJA_DATA = [
+    Rule(
+        name="jinja_set_block_start",
+        priority=100,
+        pattern=group(JINJA_SHARED_PATTERNS["set"]),
+        action=partial(
+            actions.handle_jinja_data_block_start,
+            new_ruleset=None,
+            stop_exception=StopJinjaLexing,
+            raises=False,
+        ),
+    ),
+    Rule(
+        name="jinja_set_block_end",
+        priority=101,
+        pattern=group(JINJA_SHARED_PATTERNS["endset"]),
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_set_block_start",
+            reset_sql_depth=True,
+        ),
+    ),
+    Rule(
+        name="jinja_call_block_start",
+        priority=261,
+        pattern=group(JINJA_SHARED_PATTERNS["call"]),
+        action=partial(
+            actions.handle_jinja_data_block_start,
+            new_ruleset=None,
+            stop_exception=StopJinjaLexing,
+            raises=False,
+        ),
+    ),
+    Rule(
+        name="jinja_call_block_end",
+        priority=265,
+        pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_call_block_start",
+            reset_sql_depth=True,
+        ),
+    ),
+    Rule(
+        name="jinja_newline",
+        priority=500,
+        pattern=group(NEWLINE),
+        action=actions.handle_newline,
+    ),
+    Rule(
+        name="jinja_data",
+        priority=600,
+        pattern=group(r".*?") + r"\s*" + group(*JINJA_SHARED_PATTERNS.values(), r"$"),
+        action=partial(actions.add_node_to_buffer, token_type=TokenType.DATA),
+    ),
+]
 
 JINJA = [
     Rule(
@@ -15,15 +80,17 @@ JINJA = [
     Rule(
         name="jinja_set_block_start",
         priority=100,
-        pattern=group(r"\{%-?\s*set\s+[^=]+?-?%\}"),
+        pattern=group(JINJA_SHARED_PATTERNS["set"]),
         action=partial(
-            actions.handle_jinja_data_block, end_rule_name="jinja_set_block_end"
+            actions.handle_jinja_data_block_start,
+            new_ruleset=JINJA_DATA,
+            stop_exception=StopJinjaLexing,
         ),
     ),
     Rule(
         name="jinja_set_block_end",
         priority=101,
-        pattern=group(r"\{%-?\s*endset\s*-?%\}"),
+        pattern=group(JINJA_SHARED_PATTERNS["endset"]),
         action=actions.raise_sqlfmt_bracket_error,
     ),
     Rule(
@@ -62,90 +129,79 @@ JINJA = [
         name="jinja_for_block_start",
         priority=210,
         pattern=group(r"\{%-?\s*for\s+.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_for_block_start",
-            end_name="jinja_for_block_end",
-            other_names=[],
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     Rule(
         name="jinja_for_block_end",
         priority=211,
         pattern=group(r"\{%-?\s*endfor\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end, start_rule_name="jinja_for_block_start"
+        ),
     ),
     Rule(
         name="jinja_macro_block_start",
         priority=220,
         pattern=group(r"\{%-?\s*macro\s+\w+.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_macro_block_start",
-            end_name="jinja_macro_block_end",
-            other_names=[],
-            end_reset_sql_depth=True,
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     Rule(
         name="jinja_macro_block_end",
         priority=221,
         pattern=group(r"\{%-?\s*endmacro\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_macro_block_start",
+            reset_sql_depth=True,
+        ),
     ),
     Rule(
         name="jinja_test_block_start",
         priority=230,
         pattern=group(r"\{%-?\s*test\s+\w+.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_test_block_start",
-            end_name="jinja_test_block_end",
-            other_names=[],
-            end_reset_sql_depth=True,
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     Rule(
         name="jinja_test_block_end",
         priority=231,
         pattern=group(r"\{%-?\s*endtest\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_test_block_start",
+            reset_sql_depth=True,
+        ),
     ),
     Rule(
         name="jinja_snapshot_block_start",
         priority=240,
         pattern=group(r"\{%-?\s*snapshot\s+\w+.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_snapshot_block_start",
-            end_name="jinja_snapshot_block_end",
-            other_names=[],
-            end_reset_sql_depth=True,
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     Rule(
         name="jinja_snapshot_block_end",
         priority=241,
         pattern=group(r"\{%-?\s*endsnapshot\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_snapshot_block_start",
+            reset_sql_depth=True,
+        ),
     ),
     Rule(
         name="jinja_materialization_block_start",
         priority=250,
         pattern=group(r"\{%-?\s*materialization\s+\w+\s*,.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_materialization_block_start",
-            end_name="jinja_materialization_block_end",
-            other_names=[],
-            end_reset_sql_depth=True,
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     Rule(
         name="jinja_materialization_block_end",
         priority=251,
         pattern=group(r"\{%-?\s*endmaterialization\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_materialization_block_start",
+            reset_sql_depth=True,
+        ),
     ),
     # call blocks that are used to call dbt's statement macro
     # are guaranteed to contain SQL, so we can parse them
@@ -154,13 +210,7 @@ JINJA = [
         name="jinja_call_statement_block_start",
         priority=260,
         pattern=group(r"\{%-?\s*call\s+(noop_)?statement\(.*?\)\s*-?%\}"),
-        action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_call_statement_block_start",
-            end_name="jinja_call_block_end",
-            other_names=[],
-            end_reset_sql_depth=True,
-        ),
+        action=actions.handle_jinja_block_start,
     ),
     # call blocks that call other macros may contain SQL or
     # arbitrary text or data, so we need to parse the whole block
@@ -168,16 +218,22 @@ JINJA = [
     Rule(
         name="jinja_call_block_start",
         priority=261,
-        pattern=group(r"\{%-?\s*call\s+\w+.*?-?%\}"),
+        pattern=group(JINJA_SHARED_PATTERNS["call"]),
         action=partial(
-            actions.handle_jinja_data_block, end_rule_name="jinja_call_block_end"
+            actions.handle_jinja_data_block_start,
+            new_ruleset=JINJA_DATA,
+            stop_exception=StopJinjaLexing,
         ),
     ),
     Rule(
         name="jinja_call_block_end",
         priority=265,
-        pattern=group(r"\{%-?\s*endcall\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_name="jinja_call_block_start",
+            reset_sql_depth=True,
+        ),
     ),
     Rule(
         name="jinja_statement_start",

--- a/src/sqlfmt/rules/jinja.py
+++ b/src/sqlfmt/rules/jinja.py
@@ -29,7 +29,6 @@ JINJA_DATA = [
         pattern=group(JINJA_SHARED_PATTERNS["endset"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_set_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -49,7 +48,6 @@ JINJA_DATA = [
         pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_call_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -99,40 +97,19 @@ JINJA = [
         name="jinja_elif_block_start",
         priority=201,
         pattern=group(r"\{%-?\s*elif\s+\w+.*?-?%\}"),
-        action=partial(
-            actions.handle_jinja_block_keyword,
-            start_rule_names=[
-                "jinja_if_block_start",
-                "jinja_elif_block_start",
-                "jinja_else_block_start",
-            ],
-        ),
+        action=actions.handle_jinja_block_keyword,
     ),
     Rule(
         name="jinja_else_block_start",
         priority=202,
         pattern=group(r"\{%-?\s*else\s*-?%\}"),
-        action=partial(
-            actions.handle_jinja_block_keyword,
-            start_rule_names=[
-                "jinja_if_block_start",
-                "jinja_elif_block_start",
-                "jinja_else_block_start",
-            ],
-        ),
+        action=actions.handle_jinja_block_keyword,
     ),
     Rule(
         name="jinja_if_block_end",
         priority=203,
         pattern=group(r"\{%-?\s*endif\s*-?%\}"),
-        action=partial(
-            actions.handle_jinja_block_end,
-            start_rule_names=[
-                "jinja_if_block_start",
-                "jinja_elif_block_start",
-                "jinja_else_block_start",
-            ],
-        ),
+        action=actions.handle_jinja_block_end,
     ),
     Rule(
         name="jinja_for_block_start",
@@ -144,9 +121,7 @@ JINJA = [
         name="jinja_for_block_end",
         priority=211,
         pattern=group(r"\{%-?\s*endfor\s*-?%\}"),
-        action=partial(
-            actions.handle_jinja_block_end, start_rule_names=["jinja_for_block_start"]
-        ),
+        action=actions.handle_jinja_block_end,
     ),
     Rule(
         name="jinja_macro_block_start",
@@ -160,7 +135,6 @@ JINJA = [
         pattern=group(r"\{%-?\s*endmacro\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_macro_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -176,7 +150,6 @@ JINJA = [
         pattern=group(r"\{%-?\s*endtest\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_test_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -192,7 +165,6 @@ JINJA = [
         pattern=group(r"\{%-?\s*endsnapshot\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_snapshot_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -208,7 +180,6 @@ JINJA = [
         pattern=group(r"\{%-?\s*endmaterialization\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_materialization_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -239,7 +210,6 @@ JINJA = [
         pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_names=["jinja_call_statement_block_start"],
             reset_sql_depth=True,
         ),
     ),

--- a/src/sqlfmt/rules/jinja.py
+++ b/src/sqlfmt/rules/jinja.py
@@ -29,7 +29,7 @@ JINJA_DATA = [
         pattern=group(JINJA_SHARED_PATTERNS["endset"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_set_block_start",
+            start_rule_names=["jinja_set_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -49,7 +49,7 @@ JINJA_DATA = [
         pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_call_block_start",
+            start_rule_names=["jinja_call_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -93,33 +93,46 @@ JINJA = [
         name="jinja_if_block_start",
         priority=200,
         pattern=group(r"\{%-?\s*if.*?-?%\}"),
+        action=actions.handle_jinja_block_start,
+    ),
+    Rule(
+        name="jinja_elif_block_start",
+        priority=201,
+        pattern=group(r"\{%-?\s*elif\s+\w+.*?-?%\}"),
         action=partial(
-            actions.handle_jinja_block,
-            start_name="jinja_if_block_start",
-            end_name="jinja_if_block_end",
-            other_names=[
+            actions.handle_jinja_block_keyword,
+            start_rule_names=[
+                "jinja_if_block_start",
                 "jinja_elif_block_start",
                 "jinja_else_block_start",
             ],
         ),
     ),
     Rule(
-        name="jinja_elif_block_start",
-        priority=201,
-        pattern=group(r"\{%-?\s*elif\s+\w+.*?-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
-    ),
-    Rule(
         name="jinja_else_block_start",
         priority=202,
         pattern=group(r"\{%-?\s*else\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_keyword,
+            start_rule_names=[
+                "jinja_if_block_start",
+                "jinja_elif_block_start",
+                "jinja_else_block_start",
+            ],
+        ),
     ),
     Rule(
         name="jinja_if_block_end",
         priority=203,
         pattern=group(r"\{%-?\s*endif\s*-?%\}"),
-        action=actions.raise_sqlfmt_bracket_error,
+        action=partial(
+            actions.handle_jinja_block_end,
+            start_rule_names=[
+                "jinja_if_block_start",
+                "jinja_elif_block_start",
+                "jinja_else_block_start",
+            ],
+        ),
     ),
     Rule(
         name="jinja_for_block_start",
@@ -132,7 +145,7 @@ JINJA = [
         priority=211,
         pattern=group(r"\{%-?\s*endfor\s*-?%\}"),
         action=partial(
-            actions.handle_jinja_block_end, start_rule_name="jinja_for_block_start"
+            actions.handle_jinja_block_end, start_rule_names=["jinja_for_block_start"]
         ),
     ),
     Rule(
@@ -147,7 +160,7 @@ JINJA = [
         pattern=group(r"\{%-?\s*endmacro\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_macro_block_start",
+            start_rule_names=["jinja_macro_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -163,7 +176,7 @@ JINJA = [
         pattern=group(r"\{%-?\s*endtest\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_test_block_start",
+            start_rule_names=["jinja_test_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -179,7 +192,7 @@ JINJA = [
         pattern=group(r"\{%-?\s*endsnapshot\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_snapshot_block_start",
+            start_rule_names=["jinja_snapshot_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -195,7 +208,7 @@ JINJA = [
         pattern=group(r"\{%-?\s*endmaterialization\s*-?%\}"),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_materialization_block_start",
+            start_rule_names=["jinja_materialization_block_start"],
             reset_sql_depth=True,
         ),
     ),
@@ -226,7 +239,7 @@ JINJA = [
         pattern=group(JINJA_SHARED_PATTERNS["endcall"]),
         action=partial(
             actions.handle_jinja_block_end,
-            start_rule_name="jinja_call_block_start",
+            start_rule_names=["jinja_call_statement_block_start"],
             reset_sql_depth=True,
         ),
     ),

--- a/src/sqlfmt/rules/jinja.py
+++ b/src/sqlfmt/rules/jinja.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 from sqlfmt import actions
-from sqlfmt.exception import StopJinjaLexing
 from sqlfmt.rule import Rule
 from sqlfmt.rules.common import NEWLINE, group
 from sqlfmt.token import TokenType
@@ -21,7 +20,6 @@ JINJA_DATA = [
         action=partial(
             actions.handle_jinja_data_block_start,
             new_ruleset=None,
-            stop_exception=StopJinjaLexing,
             raises=False,
         ),
     ),
@@ -42,7 +40,6 @@ JINJA_DATA = [
         action=partial(
             actions.handle_jinja_data_block_start,
             new_ruleset=None,
-            stop_exception=StopJinjaLexing,
             raises=False,
         ),
     ),
@@ -84,7 +81,6 @@ JINJA = [
         action=partial(
             actions.handle_jinja_data_block_start,
             new_ruleset=JINJA_DATA,
-            stop_exception=StopJinjaLexing,
         ),
     ),
     Rule(
@@ -222,7 +218,6 @@ JINJA = [
         action=partial(
             actions.handle_jinja_data_block_start,
             new_ruleset=JINJA_DATA,
-            stop_exception=StopJinjaLexing,
         ),
     ),
     Rule(

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,7 +30,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="90ffb23",  # sqlfmt a7ed980
+            git_ref="091e15b",  # sqlfmt 7be6ac5
             expected_changed=3,
             expected_unchanged=2414,
             expected_errored=0,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -75,7 +75,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="dbt_utils",
             git_url="https://github.com/tconbeer/dbt-utils.git",
-            git_ref="749446c",  # sqlfmt a7ed980
+            git_ref="eb7aec4",  # sqlfmt 4f9a917
             expected_changed=2,
             expected_unchanged=129,
             expected_errored=0,

--- a/tests/data/unformatted/204_gitlab_tag_validation.sql
+++ b/tests/data/unformatted/204_gitlab_tag_validation.sql
@@ -94,10 +94,10 @@
 
 {% do log("Tags in Project: " ~ project_tags, info=true) %}
 
-        {% set query %}
+{% set query %}
             SELECT tag
             FROM {{ref('valid_tags')}}
-        {% endset %}
+{% endset %}
 
 {% set results = run_query(query) %}
 

--- a/tests/data/unformatted/214_get_unique_attributes.sql
+++ b/tests/data/unformatted/214_get_unique_attributes.sql
@@ -28,7 +28,7 @@
 {# Source: https://github.com/tconbeer/sqlfmt/issues/326 #}
 {% macro get_unique_attributes(source_table, node_col) %}
 
-{% set attribute_query %} 
+{% set attribute_query %}
     select
         distinct x.key as attributes
     from {{ source_table }} x

--- a/tests/data/unformatted/215_gitlab_get_backup_table_command.sql
+++ b/tests/data/unformatted/215_gitlab_get_backup_table_command.sql
@@ -20,9 +20,9 @@
 # https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
 {% macro get_backup_table_command(table, day_of_month) %}
 
-    {% set backup_key -%}
+{% set backup_key -%}
         day_{{ day_of_month }}/{{ table.database.lower() }}/{{ table.schema.lower() }}/{{ table.name.lower() }}/data_
-    {%- endset %}
+{%- endset %}
 
     copy into @raw.public.backup_stage/{{ backup_key }}
     from {{ table.database }}.{{ table.schema }}."{{ table.name.upper() }}"

--- a/tests/data/unformatted/217_dbt_unit_testing_csv.sql
+++ b/tests/data/unformatted/217_dbt_unit_testing_csv.sql
@@ -1,0 +1,145 @@
+{% call dbt_unit_testing.test('customers', 'should sum order values to calculate customer_lifetime_value') %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_customers', {"input_format": "csv"}) %}
+    customer_id, first_name, last_name
+    1,'',''
+  {% endcall %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_orders', {"input_format": "csv"}) %}
+    order_id,customer_id,order_date
+    1001,1,null
+    1002,1,null
+  {% endcall %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_payments', {"input_format": "csv"}) %}
+    order_id,amount
+    1001,10
+    1002,10
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    customer_id,customer_lifetime_value
+    1,20
+  {% endcall %}
+{% endcall %}
+
+{% call dbt_unit_testing.test('customers', 'should sum order values to calculate customer_lifetime_value') %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_customers', {"input_format": "csv"}) %}
+    customer_id | first_name | last_name
+    1           | ''         | ''
+  {% endcall %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_orders', {"input_format": "csv"}) %}
+    order_id | customer_id | order_date 
+    1        | 1           | null
+    2        | 1           | null
+  {% endcall %}
+  
+  {% call dbt_unit_testing.mock_ref ('stg_payments', {"input_format": "csv"}) %}
+    order_id | amount
+    1        | 10
+    2        | 10
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    customer_id | customer_lifetime_value
+    1           | 20
+  {% endcall %}
+{% endcall %}
+
+{% call dbt_unit_testing.test('customers', 'should show customer_id without orders') %}
+  {% call dbt_unit_testing.mock_ref ('stg_customers') %}
+    select 1 as customer_id, '' as first_name, '' as last_name
+  {% endcall %}
+
+  {% call dbt_unit_testing.mock_ref ('stg_orders') %}
+    select null::numeric as customer_id, null::numeric as order_id, null as order_date  
+    where false
+  {% endcall %}
+
+  {% call dbt_unit_testing.mock_ref ('stg_payments') %}
+     select null::numeric as order_id, null::numeric as amount 
+     where false
+  {% endcall %}
+  
+  {% call dbt_unit_testing.expect() %}
+    select 1 as customer_id
+  {% endcall %}
+{% endcall %}
+)))))__SQLFMT_OUTPUT__(((((
+{% call dbt_unit_testing.test(
+    "customers",
+    "should sum order values to calculate customer_lifetime_value"
+) %}
+
+{% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
+    customer_id, first_name, last_name
+    1,'',''
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
+    order_id,customer_id,order_date
+    1001,1,null
+    1002,1,null
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
+    order_id,amount
+    1001,10
+    1002,10
+{% endcall %}
+
+{% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    customer_id,customer_lifetime_value
+    1,20
+{% endcall %}
+{% endcall %}
+
+{% call dbt_unit_testing.test(
+    "customers",
+    "should sum order values to calculate customer_lifetime_value"
+) %}
+
+{% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
+    customer_id | first_name | last_name
+    1           | ''         | ''
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
+    order_id | customer_id | order_date 
+    1        | 1           | null
+    2        | 1           | null
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
+    order_id | amount
+    1        | 10
+    2        | 10
+{% endcall %}
+
+{% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    customer_id | customer_lifetime_value
+    1           | 20
+{% endcall %}
+{% endcall %}
+
+{% call dbt_unit_testing.test("customers", "should show customer_id without orders") %}
+{% call dbt_unit_testing.mock_ref("stg_customers") %}
+    select 1 as customer_id, '' as first_name, '' as last_name
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_orders") %}
+    select null::numeric as customer_id, null::numeric as order_id, null as order_date  
+    where false
+{% endcall %}
+
+{% call dbt_unit_testing.mock_ref("stg_payments") %}
+     select null::numeric as order_id, null::numeric as amount 
+     where false
+{% endcall %}
+
+{% call dbt_unit_testing.expect() %}
+    select 1 as customer_id
+{% endcall %}
+{% endcall %}

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -56,6 +56,7 @@ from tests.util import check_formatting, read_test_data
         "unformatted/214_get_unique_attributes.sql",
         "unformatted/215_gitlab_get_backup_table_command.sql",
         "unformatted/216_gitlab_zuora_revenue_revenue_contract_line_source.sql",
+        "unformatted/217_dbt_unit_testing_csv.sql",
         "unformatted/300_jinjafmt.sql",
         "unformatted/400_create_fn_and_select.sql",
         "unformatted/401_explain_select.sql",

--- a/tests/unit_tests/test_actions.py
+++ b/tests/unit_tests/test_actions.py
@@ -4,7 +4,7 @@ import pytest
 
 from sqlfmt import actions
 from sqlfmt.analyzer import Analyzer
-from sqlfmt.exception import SqlfmtBracketError, StopJinjaLexing
+from sqlfmt.exception import SqlfmtBracketError, StopRulesetLexing
 from sqlfmt.rules import FUNCTION, JINJA
 from sqlfmt.token import Token, TokenType
 
@@ -266,7 +266,7 @@ def test_handle_jinja(
     start_rule = jinja_analyzer.get_rule(start_name)
     match = start_rule.program.match(source_string)
     assert match, "Start Rule does not match start of test string"
-    with pytest.raises(StopJinjaLexing):
+    with pytest.raises(StopRulesetLexing):
         actions.handle_jinja(
             jinja_analyzer, source_string, match, start_name, end_name, token_type
         )
@@ -287,7 +287,7 @@ def test_handle_jinja_set_block(jinja_analyzer: Analyzer, source_string: str) ->
     start_rule = jinja_analyzer.get_rule("jinja_set_block_start")
     match = start_rule.program.match(source_string)
     assert match is not None
-    with pytest.raises(StopJinjaLexing):
+    with pytest.raises(StopRulesetLexing):
         actions.handle_jinja_data_block(
             jinja_analyzer, source_string, match, end_rule_name="jinja_set_block_end"
         )
@@ -353,7 +353,7 @@ def test_handle_jinja_if_block(jinja_analyzer: Analyzer) -> None:
     start_rule = jinja_analyzer.get_rule("jinja_if_block_start")
     match = start_rule.program.match(source_string)
     assert match is not None
-    with pytest.raises(StopJinjaLexing):
+    with pytest.raises(StopRulesetLexing):
         actions.handle_jinja_block(
             jinja_analyzer,
             source_string,
@@ -411,7 +411,7 @@ def test_handle_jinja_if_block_nested(jinja_analyzer: Analyzer) -> None:
     start_rule = jinja_analyzer.get_rule("jinja_if_block_start")
     match = start_rule.program.match(source_string)
     assert match is not None
-    with pytest.raises(StopJinjaLexing):
+    with pytest.raises(StopRulesetLexing):
         actions.handle_jinja_block(
             jinja_analyzer,
             source_string,

--- a/tests/unit_tests/test_actions.py
+++ b/tests/unit_tests/test_actions.py
@@ -314,6 +314,34 @@ def test_handle_jinja_set_block_unterminated(jinja_analyzer: Analyzer) -> None:
     assert "{% endset %}" in str(excinfo.value)
 
 
+def test_handle_jinja_set_block_nested(default_analyzer: Analyzer) -> None:
+    source_string = """
+    {% set foo %}
+    !
+    something_else
+    {% set bar %}bar{% endset %}
+    {{ bar }}
+    {% set baz %}
+    baz
+    {% endset %}
+    {{ baz ~ bar }}
+    {% endset %}
+    """.strip()
+    q = default_analyzer.parse_query(source_string=source_string)
+    assert q.lines[0].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+    assert q.lines[1].nodes[0].token.type == TokenType.DATA
+    assert q.lines[2].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+    assert q.lines[2].nodes[1].token.type == TokenType.DATA
+    assert len(q.lines[2].nodes[1].open_jinja_blocks) == 2
+    assert q.lines[2].nodes[2].token.type == TokenType.JINJA_BLOCK_END
+    assert q.lines[3].nodes[0].token.type == TokenType.DATA
+    assert q.lines[4].nodes[0].token.type == TokenType.JINJA_BLOCK_START
+    assert q.lines[5].nodes[0].token.type == TokenType.DATA
+    assert q.lines[6].nodes[0].token.type == TokenType.JINJA_BLOCK_END
+    assert q.lines[7].nodes[0].token.type == TokenType.DATA
+    assert q.lines[8].nodes[0].token.type == TokenType.JINJA_BLOCK_END
+
+
 def test_handle_jinja_if_block(jinja_analyzer: Analyzer) -> None:
     source_string = """
     {% if foo == bar %}
@@ -414,7 +442,7 @@ def test_handle_jinja_if_block_nested(jinja_analyzer: Analyzer) -> None:
     assert jinja_analyzer.node_buffer[-1].token.type is TokenType.JINJA_BLOCK_END
 
 
-def test_handle_jinja_for_block(jinja_analyzer: Analyzer) -> None:
+def test_handle_jinja_for_block(default_analyzer: Analyzer) -> None:
     source_string = """
     {% for source in var('marketing_warehouse_ad_group_sources') %}
         {% set relation_source = 'stg_' + source + '_ad_groups' %}
@@ -427,20 +455,23 @@ def test_handle_jinja_for_block(jinja_analyzer: Analyzer) -> None:
             {% if not loop.last %}union all{% endif %}
     {% endfor %}
     """.strip()
-    start_rule = jinja_analyzer.get_rule("jinja_for_block_start")
-    match = start_rule.program.match(source_string)
-    assert match is not None, "Did not match starting block"
-    with pytest.raises(StopJinjaLexing):
-        start_rule.action(jinja_analyzer, source_string, match)
-    assert len(jinja_analyzer.line_buffer) == 9
-    assert (
-        jinja_analyzer.line_buffer[0].nodes[0].token.type is TokenType.JINJA_BLOCK_START
-    )
-    assert (
-        jinja_analyzer.line_buffer[1].nodes[0].token.type is TokenType.JINJA_STATEMENT
-    )
-    assert len(jinja_analyzer.node_buffer) == 1
-    assert jinja_analyzer.node_buffer[-1].token.type is TokenType.JINJA_BLOCK_END
+    query = default_analyzer.parse_query(source_string=source_string)
+    assert len(query.lines) == 10
+    start_node = query.nodes[0]
+    assert start_node.token.type is TokenType.JINJA_BLOCK_START
+    assert query.nodes[1].open_jinja_blocks == [start_node]
+    assert query.nodes[-2].token.type is TokenType.JINJA_BLOCK_END
+
+
+@pytest.mark.parametrize(
+    "source_string",
+    ["{% endfor %}", "{% if foo %}{% endfor %}", "{% for foo in bar %}{% endif %}"],
+)
+def test_handle_jinja_end_block_raises(
+    default_analyzer: Analyzer, source_string: str
+) -> None:
+    with pytest.raises(SqlfmtBracketError):
+        _ = default_analyzer.parse_query(source_string=source_string)
 
 
 def test_handle_jinja_call_statement_block(default_analyzer: Analyzer) -> None:
@@ -467,14 +498,17 @@ def test_handle_jinja_call_block(default_analyzer: Analyzer) -> None:
     select 1,
     {% call dbt_unit_testing.mock_ref('foo') %}
     a | b
-    11 | 12
+    foo | bar
     {% endcall %}
     2
     """.strip()
     query = default_analyzer.parse_query(source_string=source_string.lstrip())
 
-    assert query.lines[1].nodes[0].token.type is TokenType.DATA
-    assert query.lines[2].nodes[0].token.type is TokenType.NUMBER
+    assert query.lines[1].nodes[0].token.type is TokenType.JINJA_BLOCK_START
+    assert query.lines[1].nodes[1].token.type is TokenType.NEWLINE
+    assert query.lines[2].nodes[0].token.type is TokenType.DATA
+    assert query.lines[3].nodes[0].token.type is TokenType.JINJA_BLOCK_END
+    assert query.lines[4].nodes[0].token.type is TokenType.NUMBER
 
     # ensure call block does not change sql depth
     outer_select = query.nodes[0]

--- a/tests/unit_tests/test_actions.py
+++ b/tests/unit_tests/test_actions.py
@@ -395,6 +395,25 @@ def test_handle_jinja_end_block_raises(
         _ = default_analyzer.parse_query(source_string=source_string)
 
 
+@pytest.mark.parametrize(
+    "source_string",
+    [
+        "{% for foo in bar %} {% endfor %}",
+        "{% if foo %}{% endif %}",
+        "{% if foo %} {% else %}{% endif %}",
+        "{% set foo %}{% endset %}",
+        "{% call noop_statement('main', status_string) %}{% endcall %}",
+    ],
+)
+def test_handle_jinja_empty_blocks(
+    default_analyzer: Analyzer, source_string: str
+) -> None:
+    q = default_analyzer.parse_query(source_string=source_string)
+    assert len(q.lines) == 1
+    assert q.nodes[0].token.type is TokenType.JINJA_BLOCK_START
+    assert q.nodes[-2].token.type is TokenType.JINJA_BLOCK_END
+
+
 def test_handle_jinja_call_statement_block(default_analyzer: Analyzer) -> None:
     source_string = """
     select 1,

--- a/tests/unit_tests/test_splitter.py
+++ b/tests/unit_tests/test_splitter.py
@@ -325,3 +325,15 @@ def test_split_between_brackets(
         "    )\n",
     ]
     assert actual_result == expected_result
+
+
+def test_split_around_data(splitter: LineSplitter, default_analyzer: Analyzer) -> None:
+    source_string = "{% set foo %}//my one-line //data{% endset %}\n"
+    raw_query = default_analyzer.parse_query(source_string)
+
+    split_lines: List[Line] = []
+    for raw_line in raw_query.lines:
+        split_lines.extend(splitter.maybe_split(raw_line))
+
+    actual_result = [str(line) for line in split_lines]
+    assert actual_result == [source_string]


### PR DESCRIPTION
This closes #338 , and also handles some long-overdue refactoring of how we lex jinja blocks. Namely, now that we support multiple rulesets, we can do more of the lexing in the main loop, rather than in a specialized jinja-block-specific loop. This actually simplifies quite a bit of the lexing logic.

- wip: refactor jinja lexing
- refactor: use a single StopLexing exception'
- refactor: handle jinja block keywords with new action
- refactor: remove unused analyzer.stops
- fix: allow empty jinja blocks
- fix: fix issue with whitespace and data tokens
- chore: bump primer ref
