### PR TITLE
Match end of suffix against .sql and .sql.jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Formatting Changes + Bug Fixes
 
 -   sqlfmt now supports `create <object> ... clone` statements ([#313](https://github.com/tconbeer/sqlfmt/issues/313)).
--   sqlfmt now supports all files that end with `*.sql` and `*.sql.jinja`.
+-   sqlfmt will now format all files that end with `*.sql` and `*.sql.jinja`, even those with other dots in their filenames ([#354](https://github.com/tconbeer/sqlfmt/issues/354) - thank you [@ysmilda](https://github.com/ysmilda)!).
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Formatting Changes + Bug Fixes
 
 -   sqlfmt now supports `create <object> ... clone` statements ([#313](https://github.com/tconbeer/sqlfmt/issues/313)).
+-   sqlfmt now supports all files that end with `*.sql` and `*.sql.jinja`.
 
 ### Features
 

--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -140,7 +140,7 @@ def _get_included_paths(paths: Iterable[Path], mode: Mode) -> Set[Path]:
     for p in paths:
         if p == STDIN_PATH:
             include_set.add(p)
-        elif p.is_file() and str(p).endswith(mode.SQL_EXTENSIONS):
+        elif p.is_file() and str(p).endswith(tuple(mode.SQL_EXTENSIONS)):
             include_set.add(p)
         elif p.is_dir():
             include_set |= _get_included_paths(p.iterdir(), mode)

--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -140,7 +140,7 @@ def _get_included_paths(paths: Iterable[Path], mode: Mode) -> Set[Path]:
     for p in paths:
         if p == STDIN_PATH:
             include_set.add(p)
-        elif p.is_file() and "".join(p.suffixes) in (mode.SQL_EXTENSIONS):
+        elif p.is_file() and str(p).endswith(mode.SQL_EXTENSIONS):
             include_set.add(p)
         elif p.is_dir():
             include_set |= _get_included_paths(p.iterdir(), mode)

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List
 
 from sqlfmt.dialect import ClickHouse, Polyglot
 from sqlfmt.exception import SqlfmtConfigError
@@ -13,7 +13,7 @@ class Mode:
     report config. For more info on each option, see cli.py
     """
 
-    SQL_EXTENSIONS: Tuple = (".sql", ".sql.jinja")
+    SQL_EXTENSIONS: List[str] = field(default_factory=lambda: [".sql", ".sql.jinja"])
     dialect_name: str = "polyglot"
     line_length: int = 88
     check: bool = False

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Tuple
 
 from sqlfmt.dialect import ClickHouse, Polyglot
 from sqlfmt.exception import SqlfmtConfigError
@@ -13,7 +13,7 @@ class Mode:
     report config. For more info on each option, see cli.py
     """
 
-    SQL_EXTENSIONS: List[str] = field(default_factory=lambda: [".sql", ".sql.jinja"])
+    SQL_EXTENSIONS: Tuple = (".sql", ".sql.jinja")
     dialect_name: str = "polyglot"
     line_length: int = 88
     check: bool = False

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -48,9 +48,9 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="73e483c",  # sqlfmt a7ed980
+            git_ref="b0202bd",  # sqlfmt 87b3913
             expected_changed=0,
-            expected_unchanged=1702,
+            expected_unchanged=1729,
             expected_errored=0,
             sub_directory=Path("sql"),
         ),

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -35,6 +35,7 @@ def test_file_discovery(default_mode: Mode) -> None:
 
     expected = (
         p / "top_level_file.sql",
+        p / "top_level_file.two.sql",
         p / "a_directory/one_file.sql",
         p / "a_directory/nested_directory/another_file.sql",
         p / "a_directory/nested_directory/j2_extension.sql.jinja",


### PR DESCRIPTION
Closes #354 

This allows to use the CLI against files which are named `.{something}.sql` and `.{something}.sql.jinja`.

I'll be the first to admit that I know nothing about python as a language, so there might be a better way of doing this. But it passes the tests and explains my issues goal.