### PR TITLE
Add docker container option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,3 +45,19 @@ jobs:
             LICENSE
             dist/*sqlfmt*.whl
             dist/*sqlfmt*.tar.gz
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:v${{ steps.sqlfmt_version.outputs.sqlfmt_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+ -  Now available via a Docker container 
+
 ## [0.15.0] - 2023-01-18
 
 ### Formatting Changes + Bug Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3-slim
+
+COPY dist/*.whl .
+RUN pip install $(find . -name "*.whl")
+RUN mkdir format
+
+CMD sqlfmt ./format


### PR DESCRIPTION
To make it easier to run the formatter in environments without python installed I propose to add a docker container to the repo which can be pulled and used to format files in an existing folder.

The proposed syntax for running the formatter would be `docker run -v $(pwd)/{folder}:/format ghcr.io/sqlfmt:latest`

What still needs to be added is version tagged releasing to the container hub.