### PR TITLE
Add multiple platforms to docker build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This will help to speed up the container on ARM machines like the the newer Apple products.