### PR TITLE
Comments, revisited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Formatting Changes + Bug Fixes
 
+-   sqlfmt no longer merges lines that contiain comments, in order to preserve the positional meaning of those comments ([#348](https://github.com/tconbeer/sqlfmt/issues/348) - thank you, [@rileyschack](https://github.com/rileyschack) and [@IanEdington](https://github.com/IanEdington)!).
 -   sqlfmt no longer merges together lines containing multiline jinja blocks unless those lines start with an operator or comma ([#365](https://github.com/tconbeer/sqlfmt/issues/365) - thank you, [@gavlt](https://github.com/gavlt)!).
 -   fixed a bug where adding a jinja end tag (e.g., `{% endif %}`) to a line could cause bad formatting of everything on that line
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Formatting Changes + Bug Fixes
 
--   sqlfmt no longer merges lines that contain comments, unless the position of those comments can be preserved ([#348](https://github.com/tconbeer/sqlfmt/issues/348) - thank you, [@rileyschack](https://github.com/rileyschack) and [@IanEdington](https://github.com/IanEdington)!).
+-   sqlfmt no longer merges lines that contain comments, unless the position of those comments can be preserved ([#348](https://github.com/tconbeer/sqlfmt/issues/348) - thank you, [@rileyschack](https://github.com/rileyschack) and [@IanEdington](https://github.com/IanEdington)!). Accordingly, comments that are inline will stay inline, even if they are too long to fit.
 -   sqlfmt no longer merges together lines containing multiline jinja blocks unless those lines start with an operator or comma ([#365](https://github.com/tconbeer/sqlfmt/issues/365) - thank you, [@gavlt](https://github.com/gavlt)!).
 -   fixed a bug where adding a jinja end tag (e.g., `{% endif %}`) to a line could cause bad formatting of everything on that line
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Formatting Changes + Bug Fixes
 
--   sqlfmt no longer merges lines that contiain comments, in order to preserve the positional meaning of those comments ([#348](https://github.com/tconbeer/sqlfmt/issues/348) - thank you, [@rileyschack](https://github.com/rileyschack) and [@IanEdington](https://github.com/IanEdington)!).
+-   sqlfmt no longer merges lines that contain comments, unless the position of those comments can be preserved ([#348](https://github.com/tconbeer/sqlfmt/issues/348) - thank you, [@rileyschack](https://github.com/rileyschack) and [@IanEdington](https://github.com/IanEdington)!).
 -   sqlfmt no longer merges together lines containing multiline jinja blocks unless those lines start with an operator or comma ([#365](https://github.com/tconbeer/sqlfmt/issues/365) - thank you, [@gavlt](https://github.com/gavlt)!).
 -   fixed a bug where adding a jinja end tag (e.g., `{% endif %}`) to a line could cause bad formatting of everything on that line
 

--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -2,7 +2,6 @@ import re
 from dataclasses import dataclass
 from typing import ClassVar, Iterator, Tuple
 
-from sqlfmt.exception import InlineCommentException
 from sqlfmt.token import Token
 
 
@@ -68,20 +67,16 @@ class Comment:
         """
         return "\n" in self.token.token
 
-    def render_inline(self, max_length: int, content_length: int) -> str:
+    @property
+    def was_parsed_inline(self) -> bool:
+        return not self.is_standalone and not self.is_multiline
+
+    def render_inline(self) -> str:
         """
-        For a Comment, returns the string for properly formatting this Comment
-        inline, after content_length characters of non-comment Nodes
+        Renders a comment as an inline comment, assuming it'll fit.
         """
-        if self.is_standalone:
-            raise InlineCommentException("Can't inline standalone comment")
-        else:
-            inline_prefix = " " * 2
-            rendered = inline_prefix + str(self)
-            if content_length + len(rendered) > max_length:
-                raise InlineCommentException("Comment too long to be inlined")
-            else:
-                return inline_prefix + str(self)
+        inline_prefix = " " * 2
+        return f"{inline_prefix}{self}"
 
     def render_standalone(self, max_length: int, prefix: str) -> str:
         """

--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -68,7 +68,7 @@ class Comment:
         return "\n" in self.token.token
 
     @property
-    def was_parsed_inline(self) -> bool:
+    def is_inline(self) -> bool:
         return not self.is_standalone and not self.is_multiline
 
     def render_inline(self) -> str:

--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -95,7 +95,7 @@ class Comment:
                     available_length = max_length - len(prefix) - len(marker) - 2
                     line_gen = self._split_before(comment_text, available_length)
                     return "".join(
-                        [prefix + marker + " " + txt + "\n" for txt in line_gen]
+                        [prefix + marker + " " + txt.strip() + "\n" for txt in line_gen]
                     )
                 else:  # block-style or jinja comment. Don't wrap long lines for now
                     return prefix + str(self)

--- a/src/sqlfmt/exception.py
+++ b/src/sqlfmt/exception.py
@@ -64,15 +64,6 @@ class SqlfmtControlFlowException(Exception):
     pass
 
 
-class InlineCommentException(SqlfmtControlFlowException):
-    """
-    Raised by the Line class if we try to render a comment
-    inline that is too long
-    """
-
-    pass
-
-
 class StopRulesetLexing(SqlfmtControlFlowException):
     """
     Raised by the Analyzer or one of its actions to indicate

--- a/src/sqlfmt/jinjafmt.py
+++ b/src/sqlfmt/jinjafmt.py
@@ -370,7 +370,7 @@ class JinjaFormatter:
                                 for new_line, _ in [
                                     splitter.split_at_index(line, 0, i, line.comments),
                                     splitter.split_at_index(
-                                        line, i, -1, [], is_tail=True
+                                        line, i, -1, [], no_tail=True
                                     ),
                                 ]
                             ]

--- a/src/sqlfmt/jinjafmt.py
+++ b/src/sqlfmt/jinjafmt.py
@@ -367,9 +367,11 @@ class JinjaFormatter:
                         chain(
                             *[
                                 self.format_line(new_line)
-                                for new_line in [
+                                for new_line, _ in [
                                     splitter.split_at_index(line, 0, i, line.comments),
-                                    splitter.split_at_index(line, i, -1, []),
+                                    splitter.split_at_index(
+                                        line, i, -1, [], is_tail=True
+                                    ),
                                 ]
                             ]
                         )

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -87,18 +87,16 @@ class Line:
         prefix = INDENT * self.depth[0]
         return prefix
 
-    def has_inline_comment(self, max_length: int) -> bool:
+    @property
+    def has_inline_comment(self) -> bool:
         """
         Returns true if the line has an attached comment that was parsed
-        as an inline comment, and if the line and comment are short
-        enough to be rendered inline. Returns false otherwise
+        as an inline comment.
         """
-        content = str(self).rstrip()
-        if self.comments and self.comments[-1].was_parsed_inline:
-            inline_render = self.comments[-1].render_inline()
-            if len(content) + len(inline_render) <= max_length:
-                return True
-        return False
+        if self.comments and self.comments[-1].is_inline:
+            return True
+        else:
+            return False
 
     def render_with_comments(self, max_length: int) -> str:
         """
@@ -117,18 +115,11 @@ class Line:
                 # that below. Inline comments must be the last comment
                 pass
 
-        if self.has_inline_comment(max_length=max_length):
+        if self.has_inline_comment:
             rendered_lines.append(f"{content}{self.comments[-1].render_inline()}")
-        elif self.comments and self.comments[-1].was_parsed_inline:
-            # comment was parsed inline but needs to be written standalone
-            rendered_lines.append(
-                self.comments[-1].render_standalone(
-                    max_length=max_length, prefix=self.prefix
-                )
-            )
-            rendered_lines.append(f"{self}")
         else:
             rendered_lines.append(f"{self}")
+
         return "".join(rendered_lines)
 
     @classmethod

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -50,8 +50,9 @@ class LineMerger:
         except CannotMergeException:
             return lines
 
+    @classmethod
     def _extract_components(
-        self, lines: Iterable[Line]
+        cls, lines: Iterable[Line]
     ) -> Tuple[List[Node], List[Comment]]:
         """
         Given a list of lines, return 2 components:
@@ -109,7 +110,7 @@ class LineMerger:
                 )
             # skip over newline nodes
             content_nodes = [
-                self._raise_unmergeable(node, allow_multiline_jinja)
+                cls._raise_unmergeable(node, allow_multiline_jinja)
                 for node in line.nodes
                 if not node.is_newline
             ]

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -76,7 +76,15 @@ class LineMerger:
                     raise CannotMergeException(
                         "Can't merge lines with inline comments and " "other comments"
                     )
-                elif line.has_inline_comment(self.mode.line_length):
+                elif len(line.comments) == 1 and line.has_inline_comment(
+                    self.mode.line_length
+                ):
+                    has_inline_comment_above = True
+                elif (
+                    nodes
+                    and len(line.comments) == 1
+                    and line.comments[-1].was_parsed_inline
+                ):
                     has_inline_comment_above = True
                 elif nodes:
                     raise CannotMergeException(

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -69,15 +69,20 @@ class LineMerger:
         has_inline_comment_above = False
         for line in lines:
             # only merge lines with comments if it's a standalone comment
-            # above the first line
+            # above the first line or an inline comment after the last
+            # line
             if line.comments:
-                if nodes or has_inline_comment_above:
+                if has_inline_comment_above:
                     raise CannotMergeException(
-                        "Can't merge lines with comments unless the comments "
-                        "are above the first line"
+                        "Can't merge lines with inline comments and " "other comments"
                     )
                 elif line.has_inline_comment(self.mode.line_length):
                     has_inline_comment_above = True
+                elif nodes:
+                    raise CannotMergeException(
+                        "Can't merge lines with standalone comments unless the "
+                        "comments are above the first line"
+                    )
             # make an exception for inline comments followed by
             # a lonely comma (e.g., leading commas with inline comments)
             elif has_inline_comment_above:

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -81,6 +81,11 @@ class LineMerger:
                     # so it'll probably block merging unless the
                     # next line is just a comma
                     has_inline_comment_above = True
+                elif len(nodes) == 1 and nodes[0].is_operator:
+                    # if source has standalone operators, we can merge
+                    # the operator into the contents, even if there is
+                    # a comment in the way
+                    pass
                 elif nodes:
                     raise CannotMergeException(
                         "Can't merge lines with standalone comments unless the "

--- a/src/sqlfmt/merger.py
+++ b/src/sqlfmt/merger.py
@@ -76,24 +76,10 @@ class LineMerger:
                     raise CannotMergeException(
                         "Can't merge lines with inline comments and other comments"
                     )
-                elif len(line.comments) == 1 and line.has_inline_comment(
-                    self.mode.line_length
-                ):
-                    # this is a comment that can be rendered inline,
+                elif len(line.comments) == 1 and line.has_inline_comment:
+                    # this is a comment that must be rendered inline,
                     # so it'll probably block merging unless the
                     # next line is just a comma
-                    has_inline_comment_above = True
-                elif (
-                    nodes
-                    and len(line.comments) == 1
-                    and line.comments[-1].was_parsed_inline
-                ):
-                    # this is a comment that was parsed inline,
-                    # but is too long to fit inline, so it'll
-                    # wrap above. It should be treated like
-                    # a standalone comment and block merging unless this is
-                    # the last line to be merged, in which case
-                    # we'll allow it
                     has_inline_comment_above = True
                 elif nodes:
                     raise CannotMergeException(

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -33,7 +33,7 @@ class LineSplitter:
                     new_lines.append(line)
                 else:
                     new_line, comments = self.split_at_index(
-                        line, head, i, comments, is_tail=True
+                        line, head, i, comments, no_tail=True
                     )
                     assert (
                         not comments
@@ -55,7 +55,7 @@ class LineSplitter:
 
             always_split_after, never_split_after = self.maybe_split_after(node)
 
-        new_line, comments = self.split_at_index(line, head, -1, comments, is_tail=True)
+        new_line, comments = self.split_at_index(line, head, -1, comments, no_tail=True)
         assert not comments, "Comments must be empty here or we'll drop them"
         new_lines.append(new_line)
         return new_lines
@@ -130,7 +130,7 @@ class LineSplitter:
         head: int,
         index: int,
         comments: List[Comment],
-        is_tail: bool = False,
+        no_tail: bool = False,
     ) -> Tuple[Line, List[Comment]]:
         """
         Return a new line comprised of the nodes line[head:index], plus a newline node.
@@ -147,7 +147,7 @@ class LineSplitter:
 
         assert new_nodes, "Cannot split a line without nodes!"
 
-        if is_tail:
+        if no_tail:
             head_comments, tail_comments = comments, []
         elif comments:
             if new_nodes[0].is_comma:

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -32,7 +32,13 @@ class LineSplitter:
                 if head == 0:
                     new_lines.append(line)
                 else:
-                    new_lines.append(self.split_at_index(line, head, i, comments))
+                    new_line, comments = self.split_at_index(
+                        line, head, i, comments, is_tail=True
+                    )
+                    assert (
+                        not comments
+                    ), "Comments must be empty here or we'll drop them"
+                    new_lines.append(new_line)
                 return new_lines
             elif (
                 i > head
@@ -40,9 +46,8 @@ class LineSplitter:
                 and not node.formatting_disabled
                 and (always_split_after or self.maybe_split_before(node))
             ):
-                new_line = self.split_at_index(line, head, i, comments)
+                new_line, comments = self.split_at_index(line, head, i, comments)
                 new_lines.append(new_line)
-                comments = []  # only first split gets original comments
                 head = i
                 # node now follows a new newline node, so we need to update
                 # its previous node (this can impact its depth)
@@ -50,7 +55,9 @@ class LineSplitter:
 
             always_split_after, never_split_after = self.maybe_split_after(node)
 
-        new_lines.append(self.split_at_index(line, head, -1, comments))
+        new_line, comments = self.split_at_index(line, head, -1, comments, is_tail=True)
+        assert not comments, "Comments must be empty here or we'll drop them"
+        new_lines.append(new_line)
         return new_lines
 
     def maybe_split_before(self, node: Node) -> bool:
@@ -118,10 +125,19 @@ class LineSplitter:
             return False, False
 
     def split_at_index(
-        self, line: Line, head: int, index: int, comments: List[Comment]
-    ) -> Line:
+        self,
+        line: Line,
+        head: int,
+        index: int,
+        comments: List[Comment],
+        is_tail: bool = False,
+    ) -> Tuple[Line, List[Comment]]:
         """
-        Return a new line comprised of the nodes line[head:index], plus a newline node
+        Return a new line comprised of the nodes line[head:index], plus a newline node.
+
+        Also return a list of comments that need to be included in the tail
+        of the split line. This includes inline comments and if the head
+        is just a comma, all comments.
         """
         if index == -1:
             new_nodes = line.nodes[head:]
@@ -129,12 +145,26 @@ class LineSplitter:
             assert index > head, "Cannot split at start of line!"
             new_nodes = line.nodes[head:index]
 
+        assert new_nodes, "Cannot split a line without nodes!"
+
+        if is_tail:
+            head_comments, tail_comments = comments, []
+        elif comments:
+            if new_nodes[0].is_comma:
+                head_comments, tail_comments = [], comments
+            elif not comments[-1].is_standalone:
+                head_comments, tail_comments = comments[:-1], [comments[-1]]
+            else:
+                head_comments, tail_comments = comments, []
+        else:
+            head_comments, tail_comments = [], []
+
         new_line = Line.from_nodes(
             previous_node=new_nodes[0].previous_node,
             nodes=new_nodes,
-            comments=comments,
+            comments=head_comments,
         )
         if not new_line.nodes[-1].is_newline:
             self.node_manager.append_newline(new_line)
 
-        return new_line
+        return new_line, tail_comments

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -149,14 +149,20 @@ class LineSplitter:
 
         if no_tail:
             head_comments, tail_comments = comments, []
+
         elif comments:
             if new_nodes[0].is_comma:
                 head_comments, tail_comments = [], comments
-            elif not comments[-1].is_standalone:
+            elif index == len(line.nodes) - 2 and line.nodes[index].is_operator:
+                # the only thing after the split is an operator + \n, so keep the
+                # comments with the stuff before the operator
+                head_comments, tail_comments = comments, []
+            elif comments[-1].is_inline:
                 head_comments, tail_comments = comments[:-1], [comments[-1]]
             else:
                 head_comments, tail_comments = comments, []
-        else:
+
+        else:  # no comments
             head_comments, tail_comments = [], []
 
         new_line = Line.from_nodes(

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,7 +30,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="7fb974f",  # sqlfmt 3a77bb8
+            git_ref="423bed3",  # sqlfmt 8ff18f2
             expected_changed=3,
             expected_unchanged=2414,
             expected_errored=0,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,7 +30,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="c786f5c",  # sqlfmt d97af4e
+            git_ref="7fb974f",  # sqlfmt 3a77bb8
             expected_changed=3,
             expected_unchanged=2414,
             expected_errored=0,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -48,7 +48,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="edc817f",  # sqlfmt 124890d
+            git_ref="414b535",  # sqlfmt faaf71b
             expected_changed=0,
             expected_unchanged=1729,
             expected_errored=0,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -48,7 +48,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="2aad62b",  # sqlfmt d620ac8
+            git_ref="edc817f",  # sqlfmt 124890d
             expected_changed=0,
             expected_unchanged=1729,
             expected_errored=0,
@@ -66,7 +66,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="jaffle_shop",
             git_url="https://github.com/tconbeer/jaffle_shop.git",
-            git_ref="1466afa",  # sqlfmt d620ac8
+            git_ref="894e5d4",  # sqlfmt 124890d
             expected_changed=0,
             expected_unchanged=5,
             expected_errored=0,
@@ -75,7 +75,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="dbt_utils",
             git_url="https://github.com/tconbeer/dbt-utils.git",
-            git_ref="8d81899",  # sqlfmt d97af4e
+            git_ref="ab55e10",  # sqlfmt 124890d
             expected_changed=0,
             expected_unchanged=131,
             expected_errored=0,

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,16 +30,16 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="423bed3",  # sqlfmt 8ff18f2
-            expected_changed=3,
-            expected_unchanged=2414,
+            git_ref="7b0001e",  # sqlfmt 125a964
+            expected_changed=1,
+            expected_unchanged=2416,
             expected_errored=0,
             sub_directory=Path("transform/snowflake-dbt/"),
         ),
         SQLProject(
             name="rittman",
             git_url="https://github.com/tconbeer/rittman_ra_data_warehouse.git",
-            git_ref="067c14b",  # sqlfmt d97af4e
+            git_ref="803b933",  # sqlfmt 125a964
             expected_changed=0,
             expected_unchanged=307,
             expected_errored=4,  # true mismatching brackets

--- a/tests/data/unformatted/101_multiline.sql
+++ b/tests/data/unformatted/101_multiline.sql
@@ -66,7 +66,7 @@ with
  # And this is a nice multiline jinja comment
  # that we will also handle.
 #}
-/* what!?! */
 select *
 from renamed
-where true
+where
+    true  /* what!?! */

--- a/tests/data/unformatted/101_multiline.sql
+++ b/tests/data/unformatted/101_multiline.sql
@@ -68,5 +68,4 @@ with
 #}
 select *
 from renamed
-where
-    true  /* what!?! */
+where true  /* what!?! */

--- a/tests/data/unformatted/102_lots_of_comments.sql
+++ b/tests/data/unformatted/102_lots_of_comments.sql
@@ -29,7 +29,7 @@ select -- not distinct
     another_thing_entirely,
     yet_another_field
     -- another standalone comment
-from a_really_long_table; -- with a super long comment that won't fit here and needs to move up
+from a_really_long_table; -- with a super long comment that won't fit here and needs to move up above the semicolon
 
 -- sometimes we like really long comments
 -- that wrap to many lines. And may even
@@ -39,10 +39,17 @@ from a_really_long_table; -- with a super long comment that won't fit here and n
 select 1
 )))))__SQLFMT_OUTPUT__(((((
 with
-    one as (select 1),  -- short
-    -- too long to be one-lined with the comment inside so it'll have to go above
-    two as (select a_long_enough_field, another_long_enough_field),
-    three as (select 1),  -- short enough
+    one as (
+        select  -- short
+            1
+    ),
+    two as (
+        -- too long to be one-lined with the comment inside so it'll have to go above
+        select a_long_enough_field, another_long_enough_field
+    ),
+    three as (
+        select 1
+    ),  -- short enough
     four as (
         -- too long to be one-lined with the comment inside so it'll have to go above
         -- and be split and wrapped
@@ -55,14 +62,14 @@ select  -- not distinct
     -- with a long comment that needs to wrap above this line
     one_really_long_field_name,
     -- a standalone comment
-    -- with another comment
-    a_short_field,
+    a_short_field,  -- with another comment
     something_else,
     another_thing_entirely,
     yet_another_field
 -- another standalone comment
--- with a super long comment that won't fit here and needs to move up
 from a_really_long_table
+-- with a super long comment that won't fit here and needs to move up above the
+-- semicolon
 ;
 
 -- sometimes we like really long comments

--- a/tests/data/unformatted/102_lots_of_comments.sql
+++ b/tests/data/unformatted/102_lots_of_comments.sql
@@ -47,9 +47,7 @@ with
         -- too long to be one-lined with the comment inside so it'll have to go above
         select a_long_enough_field, another_long_enough_field
     ),
-    three as (
-        select 1
-    ),  -- short enough
+    three as (select 1),  -- short enough
     four as (
         -- too long to be one-lined with the comment inside so it'll have to go above
         -- and be split and wrapped

--- a/tests/data/unformatted/102_lots_of_comments.sql
+++ b/tests/data/unformatted/102_lots_of_comments.sql
@@ -63,8 +63,8 @@ select  -- not distinct
     another_thing_entirely,
     yet_another_field
 -- another standalone comment
-from a_really_long_table
-;  -- an inline comment on a semicolon
+from a_really_long_table  -- an inline comment on a semicolon
+;
 
 -- sometimes we like really long comments that wrap to many lines. And may even be a
 -- paragraph! This should wrap to a few lines (we can take that liberty because it's a

--- a/tests/data/unformatted/102_lots_of_comments.sql
+++ b/tests/data/unformatted/102_lots_of_comments.sql
@@ -4,7 +4,7 @@ with
             1
     ),
     two as (
-        select --too long to be one-lined with the comment inside so it'll have to go above
+        select --too long but it's an inline comment so it has to stay here or we'll get stability issues
             a_long_enough_field,
             another_long_enough_field
     ),
@@ -12,8 +12,8 @@ with
         select 1
     ), -- short enough
     four as (
-        select --too long to be one-lined with the comment inside so it'll have to go above and be split and wrapped
-            my_table.a_field,
+        select
+            my_table.a_field, --too long but it's an inline comment so it has to stay here or we'll get stability issues
             my_table.b_field,
             my_table.c_field
         from
@@ -22,18 +22,16 @@ with
     )
 
 select -- not distinct
-    one_really_long_field_name, -- with a long comment that needs to wrap above this line
+    one_really_long_field_name, -- with a long comment that will never wrap above this line
     -- a standalone comment
     a_short_field, -- with another comment
     something_else,
     another_thing_entirely,
     yet_another_field
     -- another standalone comment
-from a_really_long_table; -- with a super long comment that won't fit here and needs to move up above the semicolon
+from a_really_long_table; -- an inline comment on a semicolon
 
--- sometimes we like really long comments
--- that wrap to many lines. And may even
--- be a paragraph!
+-- sometimes we like really long comments that wrap to many lines. And may even be a paragraph! This should wrap to a few lines (we can take that liberty because it's a standalone comment; we don't munge inline comments any more)
 --
 -- some people like blank lines between paragraphs of comments.
 select 1
@@ -44,21 +42,21 @@ with
             1
     ),
     two as (
-        -- too long to be one-lined with the comment inside so it'll have to go above
-        select a_long_enough_field, another_long_enough_field
+        select  -- too long but it's an inline comment so it has to stay here or we'll get stability issues
+            a_long_enough_field, another_long_enough_field
     ),
     three as (select 1),  -- short enough
     four as (
-        -- too long to be one-lined with the comment inside so it'll have to go above
-        -- and be split and wrapped
-        select my_table.a_field, my_table.b_field, my_table.c_field
+        select
+            my_table.a_field,  -- too long but it's an inline comment so it has to stay here or we'll get stability issues
+            my_table.b_field,
+            my_table.c_field
         from my_table
         where something == 5
     )
 
 select  -- not distinct
-    -- with a long comment that needs to wrap above this line
-    one_really_long_field_name,
+    one_really_long_field_name,  -- with a long comment that will never wrap above this line
     -- a standalone comment
     a_short_field,  -- with another comment
     something_else,
@@ -66,13 +64,11 @@ select  -- not distinct
     yet_another_field
 -- another standalone comment
 from a_really_long_table
--- with a super long comment that won't fit here and needs to move up above the
--- semicolon
-;
+;  -- an inline comment on a semicolon
 
--- sometimes we like really long comments
--- that wrap to many lines. And may even
--- be a paragraph!
+-- sometimes we like really long comments that wrap to many lines. And may even be a
+-- paragraph! This should wrap to a few lines (we can take that liberty because it's a
+-- standalone comment; we don't munge inline comments any more)
 --
 -- some people like blank lines between paragraphs of comments.
 select 1

--- a/tests/data/unformatted/113_utils_group_by.sql
+++ b/tests/data/unformatted/113_utils_group_by.sql
@@ -26,6 +26,4 @@ select
     field_a,
     count(*)
 from my_table
-where
-    something_is_true
-    {{ dbt_utils.group_by(10) }}  -- todo: keep line break
+where something_is_true {{ dbt_utils.group_by(10) }}  -- todo: keep line break

--- a/tests/data/unformatted/113_utils_group_by.sql
+++ b/tests/data/unformatted/113_utils_group_by.sql
@@ -26,4 +26,6 @@ select
     field_a,
     count(*)
 from my_table
-where something_is_true {{ dbt_utils.group_by(10) }}  -- todo: keep line break
+where
+    something_is_true
+    {{ dbt_utils.group_by(10) }}  -- todo: keep line break

--- a/tests/data/unformatted/127_more_comments.sql
+++ b/tests/data/unformatted/127_more_comments.sql
@@ -1,0 +1,52 @@
+-- source: https://github.com/tconbeer/sqlfmt/issues/348
+with table_a as (
+    select
+        /* Notice that this select statement can fit on a single line without comments */
+        col1,
+        col2, -- col2
+        /* Special column */
+        special_column,
+    from {{ ref("table_a" )}}
+)
+
+/* Some interesting comments above a CTE with a leading comma */
+, table_b as (
+    select *
+    from {{ ref("table_b") }}
+)
+
+select *
+from table_a, table_b;
+
+select 1
+-- two
+, 2 -- two inline
+-- three
+, 3 -- three inline
+, 4 -- four inline
+)))))__SQLFMT_OUTPUT__(((((
+-- source: https://github.com/tconbeer/sqlfmt/issues/348
+with
+    table_a as (
+        select
+            /* Notice that this select statement can fit on a single line without comments */
+            col1,
+            col2,  -- col2
+            /* Special column */
+            special_column,
+        from {{ ref("table_a") }}
+    ),
+    /* Some interesting comments above a CTE with a leading comma */
+    table_b as (select * from {{ ref("table_b") }})
+
+select *
+from table_a, table_b
+;
+
+select
+    1,
+    -- two
+    2,  -- two inline
+    -- three
+    3,  -- three inline
+    4  -- four inline

--- a/tests/data/unformatted/200_base_model.sql
+++ b/tests/data/unformatted/200_base_model.sql
@@ -1,3 +1,42 @@
+with source as (select * from {{ source('my_application', 'users') }}),
+  renamed as (
+
+    select
+      --ids
+      id,
+      nullif(xid,'') as xid,
+
+      --date
+      created_on,
+      updated_on,
+
+      nullif(email,'') as email,
+      
+      -- names
+      nullif(full_name,'') as full_name,
+      nullif(trim(
+        case
+          when regexp_count(nullif(full_name,''), ' ') = 0
+            then nullif(full_name,'')
+          when regexp_count(nullif(full_name,''), ' ') = 1
+            then split_part(nullif(full_name,''), ' ', 1)
+          else regexp_substr(nullif(full_name,''), '.* .* ') -- let's explain what is going on here
+        end
+      ), 'TEST_USER') as first_name,
+      nullif(split_part(nullif(full_name,''), ' ', greatest(2, regexp_count(nullif(full_name,''), ' ')+1)),'') as last_name
+
+    from
+
+      source
+
+    where
+
+      nvl(is_deleted, false) is false
+      and id <> 123456 -- a very long comment about why we would exclude this user from this table that we will not wrap
+
+  )
+select * from renamed
+)))))__SQLFMT_OUTPUT__(((((
 with
     source as (select * from {{ source("my_application", "users") }}),
     renamed as (
@@ -22,8 +61,7 @@ with
                         then nullif(full_name, '')
                         when regexp_count(nullif(full_name, ''), ' ') = 1
                         then split_part(nullif(full_name, ''), ' ', 1)
-                        -- let's explain what is going on here
-                        else regexp_substr(nullif(full_name, ''), '.* .* ')
+                        else regexp_substr(nullif(full_name, ''), '.* .* ')  -- let's explain what is going on here
                     end
                 ),
                 'TEST_USER'
@@ -39,13 +77,7 @@ with
 
         from source
 
-        where
-
-            nvl(is_deleted, false) is false
-            and id
-            -- a very long comment about why we would exclude this user from this
-            -- table that we will wrap
-            <> 123456
+        where nvl(is_deleted, false) is false and id <> 123456  -- a very long comment about why we would exclude this user from this table that we will not wrap
 
     )
 select *

--- a/tests/data/unformatted/200_base_model.sql
+++ b/tests/data/unformatted/200_base_model.sql
@@ -1,42 +1,3 @@
-with source as (select * from {{ source('my_application', 'users') }}),
-  renamed as (
-
-    select
-      --ids
-      id,
-      nullif(xid,'') as xid,
-
-      --date
-      created_on,
-      updated_on,
-
-      nullif(email,'') as email,
-      
-      -- names
-      nullif(full_name,'') as full_name,
-      nullif(trim(
-        case
-          when regexp_count(nullif(full_name,''), ' ') = 0
-            then nullif(full_name,'')
-          when regexp_count(nullif(full_name,''), ' ') = 1
-            then split_part(nullif(full_name,''), ' ', 1)
-          else regexp_substr(nullif(full_name,''), '.* .* ') -- let's explain what is going on here
-        end
-      ), 'TEST_USER') as first_name,
-      nullif(split_part(nullif(full_name,''), ' ', greatest(2, regexp_count(nullif(full_name,''), ' ')+1)),'') as last_name
-
-    from
-
-      source
-
-    where
-
-      nvl(is_deleted, false) is false
-      and id <> 123456 -- a very long comment about why we would exclude this user from this table that we will wrap
-
-  )
-select * from renamed
-)))))__SQLFMT_OUTPUT__(((((
 with
     source as (select * from {{ source("my_application", "users") }}),
     renamed as (
@@ -61,10 +22,8 @@ with
                         then nullif(full_name, '')
                         when regexp_count(nullif(full_name, ''), ' ') = 1
                         then split_part(nullif(full_name, ''), ' ', 1)
-                        else
-                            regexp_substr(
-                                nullif(full_name, ''), '.* .* '
-                            )  -- let's explain what is going on here
+                        -- let's explain what is going on here
+                        else regexp_substr(nullif(full_name, ''), '.* .* ')
                     end
                 ),
                 'TEST_USER'

--- a/tests/data/unformatted/200_base_model.sql
+++ b/tests/data/unformatted/200_base_model.sql
@@ -61,8 +61,10 @@ with
                         then nullif(full_name, '')
                         when regexp_count(nullif(full_name, ''), ' ') = 1
                         then split_part(nullif(full_name, ''), ' ', 1)
-                        -- let's explain what is going on here
-                        else regexp_substr(nullif(full_name, ''), '.* .* ')
+                        else
+                            regexp_substr(
+                                nullif(full_name, ''), '.* .* '
+                            )  -- let's explain what is going on here
                     end
                 ),
                 'TEST_USER'
@@ -78,9 +80,13 @@ with
 
         from source
 
-        -- a very long comment about why we would exclude this user from this table
-        -- that we will wrap
-        where nvl(is_deleted, false) is false and id <> 123456
+        where
+
+            nvl(is_deleted, false) is false
+            and id
+            -- a very long comment about why we would exclude this user from this
+            -- table that we will wrap
+            <> 123456
 
     )
 select *

--- a/tests/data/unformatted/209_rittman_int_web_events_sessionized.sql
+++ b/tests/data/unformatted/209_rittman_int_web_events_sessionized.sql
@@ -185,6 +185,8 @@ from ordered_conversion_tagged
 {% if var("product_warehouse_event_sources") %}
 
 with
+    events as (
+        select * from {{ ref("int_web_events") }}
     /*  {% if is_incremental() %}
     where visitor_id in (
         select distinct visitor_id
@@ -200,7 +202,7 @@ with
         )
     {% endif %}
 */
-    events as (select * from {{ ref("int_web_events") }}),
+    ),
 
     numbered as (
 

--- a/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
+++ b/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
@@ -34,6 +34,11 @@ where
     a
     + b
     > fooooooooobarrrrrrrr -- this is a comment that is too long to be inline here. foobar
+    and
+    -- some other condition
+    c
+    + d
+    < e
 
 )))))__SQLFMT_OUTPUT__(((((
 with  -- with
@@ -53,4 +58,7 @@ from
     tbl,  -- tbl
     second,
     third
-where a + b > fooooooooobarrrrrrrr  -- this is a comment that is too long to be inline here. foobar
+where
+    a + b > fooooooooobarrrrrrrr  -- this is a comment that is too long to be inline here. foobar
+    -- some other condition
+    and c + d < e

--- a/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
+++ b/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
@@ -34,6 +34,7 @@ where
     a
     + b
     > fooooooooobarrrrrrrr -- this is a comment that is too long to be inline here. foobar
+
 )))))__SQLFMT_OUTPUT__(((((
 with  -- with
     tbl  -- tbl

--- a/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
+++ b/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
@@ -53,5 +53,4 @@ from
     tbl,  -- tbl
     second,
     third
--- this is a comment that is too long to be inline here. foobar
-where a + b > fooooooooobarrrrrrrr
+where a + b > fooooooooobarrrrrrrr  -- this is a comment that is too long to be inline here. foobar

--- a/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
+++ b/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
@@ -1,0 +1,40 @@
+with -- with
+    tbl --tbl
+    as ( -- as
+        select -- select
+            1 -- one
+            ,
+            2 -- two inline
+            ,
+            3 -- three inline
+            ,
+            4 -- four inline
+    ) -- close
+    ,
+    second -- second
+    as (
+        select
+            1
+    )
+select
+    *
+from
+    tbl -- tbl
+    ,
+    second
+)))))__SQLFMT_OUTPUT__(((((
+with  -- with
+    tbl  -- tbl
+    as (  -- as
+        select  -- select
+            1,  -- one
+            2,  -- two inline
+            3,  -- three inline
+            4  -- four inline
+    ),  -- close
+    second  -- second
+    as (select 1)
+select *
+from
+    tbl,  -- tbl
+    second

--- a/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
+++ b/tests/data/unit_tests/test_merger/test_merge_inline_comments.sql
@@ -16,12 +16,24 @@ with -- with
         select
             1
     )
+    ,
+    third
+    as (
+        select
+            2
+    ) -- third
 select
     *
 from
     tbl -- tbl
     ,
     second
+    ,
+    third
+where
+    a
+    + b
+    > fooooooooobarrrrrrrr -- this is a comment that is too long to be inline here. foobar
 )))))__SQLFMT_OUTPUT__(((((
 with  -- with
     tbl  -- tbl
@@ -33,8 +45,12 @@ with  -- with
             4  -- four inline
     ),  -- close
     second  -- second
-    as (select 1)
+    as (select 1),
+    third as (select 2)  -- third
 select *
 from
     tbl,  -- tbl
-    second
+    second,
+    third
+-- this is a comment that is too long to be inline here. foobar
+where a + b > fooooooooobarrrrrrrr

--- a/tests/data/unit_tests/test_merger/test_no_merge_formatting_disabled.sql
+++ b/tests/data/unit_tests/test_merger/test_no_merge_formatting_disabled.sql
@@ -1,0 +1,3 @@
+-- fmt: off
+select
+    1

--- a/tests/data/unit_tests/test_merger/test_no_merge_short_multiline_nodes.sql
+++ b/tests/data/unit_tests/test_merger/test_no_merge_short_multiline_nodes.sql
@@ -1,0 +1,10 @@
+{{
+    config(enabled=false)
+}}
+select
+    1
+)))))__SQLFMT_OUTPUT__(((((
+{{
+    config(enabled=false)
+}}
+select 1

--- a/tests/data/unit_tests/test_splitter/test_simple_comment_split.sql
+++ b/tests/data/unit_tests/test_splitter/test_simple_comment_split.sql
@@ -1,6 +1,7 @@
 select -- not distinct, just an ordinary select here, no big deal at all, it's okay really
     my_first_field + an_operation, -- here is a long comment to be wrapped above this line
     my_second_field, -- a short comment
+    -- standalone for third
     my_third_field + another_long_operation -- here is another long comment to be wrapped but not indented
 from my_really_long_data_source -- another comment that is a little bit too long to stay here
 where -- this should stay

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -40,6 +40,7 @@ from tests.util import check_formatting, read_test_data
         "unformatted/124_bq_compound_types.sql",
         "unformatted/125_numeric_constants.sql",
         "unformatted/126_blank_lines.sql",
+        "unformatted/127_more_comments.sql",
         "unformatted/200_base_model.sql",
         "unformatted/201_basic_snapshot.sql",
         "unformatted/202_unpivot_macro.sql",

--- a/tests/unit_tests/test_comment.py
+++ b/tests/unit_tests/test_comment.py
@@ -132,12 +132,12 @@ def test_empty_comment() -> None:
     assert str(comment) == "--\n"
 
 
-def test_was_parsed_inline(
+def test_is_inline(
     short_comment: Comment, standalone_comment: Comment, multiline_comment: Comment
 ) -> None:
-    assert short_comment.was_parsed_inline
-    assert not (standalone_comment.was_parsed_inline)
-    assert not (multiline_comment.was_parsed_inline)
+    assert short_comment.is_inline
+    assert not (standalone_comment.is_inline)
+    assert not (multiline_comment.is_inline)
 
 
 def test_no_wrap_long_jinja_comments() -> None:

--- a/tests/unit_tests/test_comment.py
+++ b/tests/unit_tests/test_comment.py
@@ -104,6 +104,13 @@ def test_render_standalone(short_comment: Comment, prefix: str) -> None:
     assert lines[1] == prefix + "-- comment\n"
 
 
+def test_render_standalone_wrap_strip_whitespace() -> None:
+    txt = "-- foo" + " " * 100 + "bar"
+    t = Token(type=TokenType.COMMENT, prefix="", token=txt, spos=0, epos=len(txt))
+    comment = Comment(t, is_standalone=True)
+    assert comment.render_standalone(max_length=88, prefix="") == "-- foo\n-- bar\n"
+
+
 def test_render_multiline(multiline_comment: Comment) -> None:
     assert multiline_comment.render_standalone(max_length=88, prefix="") == str(
         multiline_comment

--- a/tests/unit_tests/test_comment.py
+++ b/tests/unit_tests/test_comment.py
@@ -3,7 +3,6 @@ from typing import List
 import pytest
 
 from sqlfmt.comment import Comment
-from sqlfmt.exception import InlineCommentException
 from sqlfmt.token import Token, TokenType
 
 
@@ -75,15 +74,8 @@ def test_render_inline(
     short_comment: Comment, nospace_comment: Comment, standalone_comment: Comment
 ) -> None:
     expected = "  -- short comment\n"
-    assert short_comment.render_inline(max_length=88, content_length=20) == expected
-    assert nospace_comment.render_inline(max_length=88, content_length=20) == expected
-    with pytest.raises(InlineCommentException):
-        # can't inline a standalone comment
-        assert standalone_comment.render_inline(max_length=88, content_length=20)
-
-    with pytest.raises(InlineCommentException):
-        # can't inline if the content is too long
-        assert short_comment.render_inline(max_length=88, content_length=80)
+    assert short_comment.render_inline() == expected
+    assert nospace_comment.render_inline() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -236,7 +236,7 @@ def test_long_comment_wrapping(simple_line: Line) -> None:
         spos=last_node.token.epos,
         epos=last_node.token.epos + 13,
     )
-    comment = Comment(token=comment_token, is_standalone=False)
+    comment = Comment(token=comment_token, is_standalone=True)
     simple_line.comments = [comment]
     expected_render = (
         "-- asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf "
@@ -266,9 +266,9 @@ def test_long_comments_that_are_not_wrapped(
         spos=last_node.token.epos,
         epos=last_node.token.epos + 13,
     )
-    comment = Comment(token=comment_token, is_standalone=False)
+    comment = Comment(token=comment_token, is_standalone=True)
     simple_line.comments = [comment]
-    expected_render = raw_comment + "\n" "with abc as (select * from my_table)\n"
+    expected_render = raw_comment + "\nwith abc as (select * from my_table)\n"
     assert simple_line.render_with_comments(88) == expected_render
 
 

--- a/tests/unit_tests/test_line.py
+++ b/tests/unit_tests/test_line.py
@@ -210,11 +210,6 @@ def test_comment_rendering(
     )
 
     inline_comment = Comment(token=comment_token, is_standalone=False)
-    node_manager.append_newline(bare_line)
-    bare_line.comments = [inline_comment]
-    expected_bare_render = normalized_comment + "\n"
-    assert bare_line.render_with_comments(88) == expected_bare_render
-
     simple_line.comments = [inline_comment]
     expected_inline_render = (
         str(simple_line).rstrip() + "  " + normalized_comment + "\n"
@@ -227,18 +222,6 @@ def test_comment_rendering(
         simple_line.prefix + normalized_comment + "\n" + str(simple_line)
     )
     assert simple_line.render_with_comments(88) == expected_standalone_render
-
-    simple_line.comments = [standalone_comment, inline_comment]
-    expected_multiple_render = (
-        simple_line.prefix
-        + normalized_comment
-        + "\n"
-        + simple_line.prefix
-        + normalized_comment
-        + "\n"
-        + str(simple_line)
-    )
-    assert simple_line.render_with_comments(88) == expected_multiple_render
 
 
 def test_long_comment_wrapping(simple_line: Line) -> None:

--- a/tests/unit_tests/test_merger.py
+++ b/tests/unit_tests/test_merger.py
@@ -514,3 +514,39 @@ def test_fix_standalone_operators(merger: LineMerger) -> None:
 
     result_string = "".join([str(line) for line in itertools.chain(*fixed_segments)])
     assert result_string == expected_string
+
+
+def test_merge_inline_comments(merger: LineMerger) -> None:
+    source_string, expected_string = read_test_data(
+        "unit_tests/test_merger/test_merge_inline_comments.sql"
+    )
+    raw_query = merger.mode.dialect.initialize_analyzer(
+        merger.mode.line_length
+    ).parse_query(source_string)
+    merged_lines = merger.maybe_merge_lines(raw_query.lines)
+    result_string = "".join([line.render_with_comments(88) for line in merged_lines])
+    assert result_string == expected_string
+
+
+def test_no_merge_short_multiline_nodes(merger: LineMerger) -> None:
+    source_string, expected_string = read_test_data(
+        "unit_tests/test_merger/test_no_merge_short_multiline_nodes.sql"
+    )
+    raw_query = merger.mode.dialect.initialize_analyzer(
+        merger.mode.line_length
+    ).parse_query(source_string)
+    merged_lines = merger.maybe_merge_lines(raw_query.lines)
+    result_string = "".join([line.render_with_comments(88) for line in merged_lines])
+    assert result_string == expected_string
+
+
+def test_no_merge_formatting_disabled(merger: LineMerger) -> None:
+    source_string, expected_string = read_test_data(
+        "unit_tests/test_merger/test_no_merge_formatting_disabled.sql"
+    )
+    raw_query = merger.mode.dialect.initialize_analyzer(
+        merger.mode.line_length
+    ).parse_query(source_string)
+    merged_lines = merger.maybe_merge_lines(raw_query.lines)
+    result_string = "".join([str(line) for line in merged_lines])
+    assert result_string == expected_string

--- a/tests/unit_tests/test_merger.py
+++ b/tests/unit_tests/test_merger.py
@@ -21,10 +21,6 @@ def test_create_merged_line(merger: LineMerger) -> None:
     select
         able,
         baker,
-        /*  a
-            multiline
-            comment
-        */
 
 
 
@@ -54,6 +50,26 @@ def test_create_merged_line(merger: LineMerger) -> None:
     with pytest.raises(CannotMergeException):
         # can't merge whitespace
         _ = merger.create_merged_line(raw_query.lines[-6:-3])
+
+
+def test_create_merged_line_comments(merger: LineMerger) -> None:
+
+    source_string = """
+    select
+        able,
+        baker,
+        -- a comment
+        charlie,
+    """
+    raw_query = merger.mode.dialect.initialize_analyzer(
+        merger.mode.line_length
+    ).parse_query(source_string)
+
+    with pytest.raises(CannotMergeException) as exc_info:
+        # can't merge whitespace
+        _ = merger.create_merged_line(raw_query.lines)
+
+    assert "comment" in str(exc_info.value)
 
 
 def test_basic_merge(merger: LineMerger) -> None:

--- a/tests/unit_tests/test_splitter.py
+++ b/tests/unit_tests/test_splitter.py
@@ -439,6 +439,36 @@ def test_split_leading_comma_comment(
     assert actual_result == expected_result
 
 
+def test_split_trailing_operator_comment(
+    splitter: LineSplitter, default_analyzer: Analyzer
+) -> None:
+    source_string = """
+    select
+        1 + -- one
+        2 + -- two
+        3 + 4 -- four
+    """.strip()
+
+    raw_query = default_analyzer.parse_query(source_string)
+    assert len(raw_query.lines) == 4
+
+    split_lines: List[Line] = []
+    for raw_line in raw_query.lines:
+        split_lines.extend(splitter.maybe_split(raw_line))
+
+    actual_result = [line.render_with_comments(88) for line in split_lines]
+    expected_result = [
+        "select\n",
+        "    1  -- one\n",
+        "    +\n",
+        "    2  -- two\n",
+        "    +\n",
+        "    3\n",
+        "    + 4  -- four\n",
+    ]
+    assert actual_result == expected_result
+
+
 def test_split_formatting_disabled(
     splitter: LineSplitter, default_analyzer: Analyzer
 ) -> None:

--- a/tests/unit_tests/test_splitter.py
+++ b/tests/unit_tests/test_splitter.py
@@ -78,13 +78,13 @@ def test_simple_comment_split(
             "-- not distinct, just an ordinary select here,"
             " no big deal at all, it's okay really\n"
         ),
-        "-- here is a long comment to be wrapped above this line\n",
         "",
+        "-- here is a long comment to be wrapped above this line\n",
         "-- a short comment\n",
+        "-- standalone for third\n",
         "-- here is another long comment to be wrapped but not indented\n",
         "",
         "-- another comment that is a little bit too long to stay here\n",
-        "",
         "-- this should stay\n",
         "",
         "-- one last comment\n",
@@ -406,4 +406,34 @@ def test_maybe_split_no_terminating_newline(
         "    3\n",
     ]
 
+    assert actual_result == expected_result
+
+
+def test_split_leading_comma_comment(
+    splitter: LineSplitter, default_analyzer: Analyzer
+) -> None:
+    source_string = """
+    select 1
+        -- two
+        , 2  -- two inline
+        -- three
+        , 3  -- three inline
+    """.strip()
+
+    raw_query = default_analyzer.parse_query(source_string)
+    assert len(raw_query.lines) == 3
+
+    split_lines: List[Line] = []
+    for raw_line in raw_query.lines:
+        split_lines.extend(splitter.maybe_split(raw_line))
+
+    actual_result = [line.render_with_comments(88) for line in split_lines]
+    expected_result = [
+        "select\n",
+        "    1\n",
+        "    ,\n",
+        "    -- two\n" "    2  -- two inline\n",
+        "    ,\n",
+        "    -- three\n" "    3  -- three inline\n",
+    ]
     assert actual_result == expected_result

--- a/tests/unit_tests/test_splitter.py
+++ b/tests/unit_tests/test_splitter.py
@@ -437,3 +437,25 @@ def test_split_leading_comma_comment(
         "    -- three\n" "    3  -- three inline\n",
     ]
     assert actual_result == expected_result
+
+
+def test_split_formatting_disabled(
+    splitter: LineSplitter, default_analyzer: Analyzer
+) -> None:
+    source_string = """
+    -- fmt: off
+    select 1, 2, 3
+    """.strip()
+
+    raw_query = default_analyzer.parse_query(source_string)
+    assert len(raw_query.lines) == 2
+    select_line = raw_query.lines[1]
+    assert select_line.formatting_disabled
+    assert select_line.nodes[0].is_unterm_keyword
+    assert select_line.nodes[0].formatting_disabled
+
+    split_lines: List[Line] = []
+    for raw_line in raw_query.lines:
+        split_lines.extend(splitter.maybe_split(raw_line))
+
+    assert split_lines == raw_query.lines


### PR DESCRIPTION
This PR ended up totally rethinking and rewriting comment handling. It was spurred by #348, but ended up doing more.

For the purposes of stability, we no longer push long inline comments to be standalone comments. This also helps
preserve the meaning of the position of the inline comments (this isn't always important, but sometimes it is).

This means that sometimes lines can exceed the max desired line length (including the inline comment).

- feat: revisit comments, close #348
- chore: improve unit testing and docs
- fix: allow merging if lines end in trailing inline comment
- fix: allow merging ahead of inline comments'
- fix: allow merging of blank lines after inline comments
- fix: keep inline comments inline
- fix: strip whitespace when splitting comments onto multiple lines
- fix: merge through comments if directly after standalone operator
- chore: bump primer refs
