### PR TITLE
Indent jinja block contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes
+-   the contents of jinja blocks are now indented if the block wraps onto multiple rows ([#403](https://github.com/tconbeer/sqlfmt/issues/403)). This is now the proper sqlfmt style:
+    ```sql
+    select
+        some_field,
+        {% for some_item in some_sequence %}
+            some_function({{ some_item }}){% if not loop.last %}, {% endif %}
+        {% endfor %}
+    ```
+    While in this simple example the new style makes it less clear 
+    that `some_field` and `some_function` are at the
+    same SQL depth, the formatting of complex files with nested jinja blocks is much improved.
+    For example:
+
+    ```sql
+    {%- for col in cols -%}
+        {%- if col.column.lower() not in remove | map(
+            "lower"
+        ) and col.column.lower() not in exclude | map("lower") -%}
+            {% do include_cols.append(col) %}
+        {%- endif %}
+    {%- endfor %}
+    ```
+    See also [this discussion](https://github.com/tconbeer/sqlfmt/discussions/317).
+
 ## [0.17.1] - 2023-04-12
 
+### Bug Fixes
 -   fixed a bug where format-off tokens could cause sqlfmt to raise a bracket mismatch error ([#395](https://github.com/tconbeer/sqlfmt/issues/395) - thank you, [@AndrewLaneAtPowerSchool](https://github.com/AndrewLaneAtPowerSchool)!).
 
 ## [0.17.0] - 2023-02-24
 
+### Features
 -   sqlfmt now defaults to reading and writing files using the `utf-8` encoding. Previously, we used Python's default behavior of using the encoding from the host machine's locale. However, as `utf-8` becomes a de-facto standard, this was causing issues for some Windows users, whose locale was set to use older encodings. You can use the `--encoding` option to specify a different encoding. Setting encoding to `inherit`, e.g., `sqlfmt --encoding inherit foo.sql` will revert to the old behavior of using the host's locale. sqlfmt will detect and preserve a UTF BOM if it is present. If you specify `--encoding utf-8-sig`, sqlfmt will always write a UTF-8 BOM in the formatted file. ([#350](https://github.com/tconbeer/sqlfmt/issues/350), [#381]((https://github.com/tconbeer/sqlfmt/issues/381)), [#383]((https://github.com/tconbeer/sqlfmt/issues/383)) - thank you [@profesia-company](https://github.com/profesia-company), [@cmcnicoll](https://github.com/cmcnicoll), [@aersam](https://github.com/aersam), and [@ryanmeekins](https://github.com/ryanmeekins)!)
 
 ## [0.16.0] - 2023-01-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ All notable changes to this project will be documented in this file.
         {%- endif %}
     {%- endfor %}
     ```
-    See also [this discussion](https://github.com/tconbeer/sqlfmt/discussions/317).
+    See also [this discussion](https://github.com/tconbeer/sqlfmt/discussions/317). Thank you 
+    [@dave-connors-3](https://github.com/dave-connors-3) and 
+    [@alrocar](https://github.com/alrocar)!
 
 ## [0.17.1] - 2023-04-12
 

--- a/src/sqlfmt/line.py
+++ b/src/sqlfmt/line.py
@@ -84,7 +84,7 @@ class Line:
         proper indentation.
         """
         INDENT = " " * 4
-        prefix = INDENT * self.depth[0]
+        prefix = INDENT * (self.depth[0] + self.depth[1])
         return prefix
 
     @property

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -30,7 +30,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="gitlab",
             git_url="https://github.com/tconbeer/gitlab-analytics-sqlfmt.git",
-            git_ref="7b0001e",  # sqlfmt 125a964
+            git_ref="b1935f4",  # sqlfmt 54b8edd
             expected_changed=1,
             expected_unchanged=2416,
             expected_errored=0,
@@ -39,7 +39,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="rittman",
             git_url="https://github.com/tconbeer/rittman_ra_data_warehouse.git",
-            git_ref="803b933",  # sqlfmt 125a964
+            git_ref="f44544f",  # sqlfmt 54b8edd
             expected_changed=0,
             expected_unchanged=307,
             expected_errored=4,  # true mismatching brackets
@@ -57,7 +57,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="aqi",
             git_url="https://github.com/tconbeer/aqi_livibility_analysis.git",
-            git_ref="b088ed1",  # sqlfmt a7ed980
+            git_ref="f313f5b",  # sqlfmt 54b8edd
             expected_changed=0,
             expected_unchanged=7,
             expected_errored=0,
@@ -66,7 +66,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="jaffle_shop",
             git_url="https://github.com/tconbeer/jaffle_shop.git",
-            git_ref="894e5d4",  # sqlfmt 124890d
+            git_ref="5e63c7c",  # sqlfmt 54b8edd
             expected_changed=0,
             expected_unchanged=5,
             expected_errored=0,
@@ -75,7 +75,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="dbt_utils",
             git_url="https://github.com/tconbeer/dbt-utils.git",
-            git_ref="ab55e10",  # sqlfmt 124890d
+            git_ref="ae160c9",  # sqlfmt 54b8edd
             expected_changed=0,
             expected_unchanged=131,
             expected_errored=0,

--- a/tests/data/unformatted/107_jinja_blocks.sql
+++ b/tests/data/unformatted/107_jinja_blocks.sql
@@ -36,7 +36,7 @@ Hello! I'm data, not code.
 
 with
     {%- for model in list_o_models %}
-    {{ model }} as (select * from {{ ref(model) }}),
+        {{ model }} as (select * from {{ ref(model) }}),
     {% endfor -%}
     base as (
         select *
@@ -48,12 +48,12 @@ with
     joined as (
         select
             {% for model in list_o_models %}
-            {{ model }}.column_a as {{ model }}_field
-            {%- if not loop.last -%},{%- endif %}
+                {{ model }}.column_a as {{ model }}_field
+                {%- if not loop.last -%},{%- endif %}
             {% endfor %}
         from base
         {% for model in list_o_models %}
-        join {{ model }} on base.{{ model }}_id = {{ model }}.id
+            join {{ model }} on base.{{ model }}_id = {{ model }}.id
         {% endfor %}
     )
 select *

--- a/tests/data/unformatted/108_test_block.sql
+++ b/tests/data/unformatted/108_test_block.sql
@@ -5,5 +5,5 @@ where {{ column_name }} < 0
 {% endtest %}
 )))))__SQLFMT_OUTPUT__(((((
 {% test nonnegative(model, column_name) %}
-select * from {{ model }} where {{ column_name }} < 0
+    select * from {{ model }} where {{ column_name }} < 0
 {% endtest %}

--- a/tests/data/unformatted/126_blank_lines.sql
+++ b/tests/data/unformatted/126_blank_lines.sql
@@ -71,7 +71,7 @@ where
     quxxxxxxxxxxx = 1
     {% if is_incremental() %}
 
-    and barrrrrrrrrr = 1 and bazzzzzzzzzzz = 2 and quxxxxxxxxxxx = 3
+        and barrrrrrrrrr = 1 and bazzzzzzzzzzz = 2 and quxxxxxxxxxxx = 3
 
     {% endif %}
 ;

--- a/tests/data/unformatted/201_basic_snapshot.sql
+++ b/tests/data/unformatted/201_basic_snapshot.sql
@@ -11,16 +11,16 @@
 select * from {{ ref('stg_my_model') }}{% endsnapshot %}
 )))))__SQLFMT_OUTPUT__(((((
 {% snapshot snp_my_snapshot %}
-{{
-    config(
-        target_database="analytics",
-        target_schema=target.schema + "_snapshots",
-        unique_key="id",
-        strategy="timestamp",
-        updated_at="updated_at",
-    )
-}}
+    {{
+        config(
+            target_database="analytics",
+            target_schema=target.schema + "_snapshots",
+            unique_key="id",
+            strategy="timestamp",
+            updated_at="updated_at",
+        )
+    }}
 
-select *
-from {{ ref("stg_my_model") }}
+    select *
+    from {{ ref("stg_my_model") }}
 {% endsnapshot %}

--- a/tests/data/unformatted/202_unpivot_macro.sql
+++ b/tests/data/unformatted/202_unpivot_macro.sql
@@ -56,43 +56,46 @@
     table=none
 ) -%}
 
-{%- set exclude = exclude if exclude is not none else [] %}
-{%- set remove = remove if remove is not none else [] %}
+    {%- set exclude = exclude if exclude is not none else [] %}
+    {%- set remove = remove if remove is not none else [] %}
 
-{%- set include_cols = [] %}
+    {%- set include_cols = [] %}
 
-{%- set table_columns = {} %}
+    {%- set table_columns = {} %}
 
-{%- do table_columns.update({relation: []}) %}
+    {%- do table_columns.update({relation: []}) %}
 
-{%- do dbt_utils._is_relation(relation, "unpivot") -%}
-{%- do dbt_utils._is_ephemeral(relation, "unpivot") -%}
-{%- set cols = adapter.get_columns_in_relation(relation) %}
+    {%- do dbt_utils._is_relation(relation, "unpivot") -%}
+    {%- do dbt_utils._is_ephemeral(relation, "unpivot") -%}
+    {%- set cols = adapter.get_columns_in_relation(relation) %}
 
-{%- for col in cols -%}
-{%- if col.column.lower() not in remove | map(
-    "lower"
-) and col.column.lower() not in exclude | map("lower") -%}
-{% do include_cols.append(col) %}
-{%- endif %}
-{%- endfor %}
+    {%- for col in cols -%}
+        {%- if col.column.lower() not in remove | map(
+            "lower"
+        ) and col.column.lower() not in exclude | map("lower") -%}
+            {% do include_cols.append(col) %}
+        {%- endif %}
+    {%- endfor %}
 
-{%- for col in include_cols -%}
-select
-    {%- for exclude_col in exclude %} {{ exclude_col }}, {%- endfor %}
+    {%- for col in include_cols -%}
+        select
+            {%- for exclude_col in exclude %} {{ exclude_col }}, {%- endfor %}
 
-    cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as {{ field_name }},
-    cast(
-        {% if col.data_type == "boolean" %}{{ dbt_utils.cast_bool_to_text(col.column) }}
-        {% else %}{{ col.column }}
-        {% endif %} as {{ cast_to }}
-    ) as {{ value_name }}
+            cast(
+                '{{ col.column }}' as {{ dbt_utils.type_string() }}
+            ) as {{ field_name }},
+            cast(
+                {% if col.data_type == "boolean" %}
+                    {{ dbt_utils.cast_bool_to_text(col.column) }}
+                {% else %}{{ col.column }}
+                {% endif %} as {{ cast_to }}
+            ) as {{ value_name }}
 
-from {{ relation }}
+        from {{ relation }}
 
-{% if not loop.last -%}
-union all
-{% endif -%}
-{%- endfor -%}
+        {% if not loop.last -%}
+            union all
+        {% endif -%}
+    {%- endfor -%}
 
 {%- endmacro %}

--- a/tests/data/unformatted/203_gitlab_email_domain_type.sql
+++ b/tests/data/unformatted/203_gitlab_email_domain_type.sql
@@ -40,41 +40,42 @@ END
 # https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
 {% macro email_domain_type(email_domain, lead_source) %}
 
-{%- set personal_email_domains_partial_match = get_personal_email_domain_list(
-    "partial_match"
-) -%}
-{%- set personal_email_domains_full_match = get_personal_email_domain_list(
-    "full_match"
-) -%}
+    {%- set personal_email_domains_partial_match = get_personal_email_domain_list(
+        "partial_match"
+    ) -%}
+    {%- set personal_email_domains_full_match = get_personal_email_domain_list(
+        "full_match"
+    ) -%}
 
-case
-    when
-        {{ lead_source }} in ('DiscoverOrg', 'Zoominfo', 'Purchased List', 'GitLab.com')
-    then 'Bulk load or list purchase or spam impacted'
-    when trim({{ email_domain }}) is null
-    then 'Missing email domain'
+    case
+        when
+            {{ lead_source }}
+            in ('DiscoverOrg', 'Zoominfo', 'Purchased List', 'GitLab.com')
+        then 'Bulk load or list purchase or spam impacted'
+        when trim({{ email_domain }}) is null
+        then 'Missing email domain'
 
-    when
-        {{ email_domain }} like any (
-            {%- for personal_email_domain in personal_email_domains_partial_match -%}
-            '%{{personal_email_domain}}%' {%- if not loop.last -%}, {% endif %}
-            {% endfor %}
-        )
+        when
+            {{ email_domain }} like any (
+                {%- for personal_email_domain in personal_email_domains_partial_match -%}
+                    '%{{personal_email_domain}}%' {%- if not loop.last -%}, {% endif %}
+                {% endfor %}
+            )
 
-        or {{ email_domain }} in (
-            {%- for personal_email_domain in personal_email_domains_full_match -%}
-            '{{personal_email_domain}}' {%- if not loop.last -%}, {% endif %}
-            {% endfor %}
-        )
+            or {{ email_domain }} in (
+                {%- for personal_email_domain in personal_email_domains_full_match -%}
+                    '{{personal_email_domain}}' {%- if not loop.last -%}, {% endif %}
+                {% endfor %}
+            )
 
-        or not {{ email_domain }} not in (
-            {%- for personal_email_domain in personal_email_domains_full_match -%}
-            '{{personal_email_domain}}' {%- if not loop.last -%}, {% endif %}
-            {% endfor %}
-        )
+            or not {{ email_domain }} not in (
+                {%- for personal_email_domain in personal_email_domains_full_match -%}
+                    '{{personal_email_domain}}' {%- if not loop.last -%}, {% endif %}
+                {% endfor %}
+            )
 
-    then 'Personal email domain'
-    else 'Business email domain'
-end
+        then 'Personal email domain'
+        else 'Business email domain'
+    end
 
 {% endmacro %}

--- a/tests/data/unformatted/204_gitlab_tag_validation.sql
+++ b/tests/data/unformatted/204_gitlab_tag_validation.sql
@@ -74,71 +74,73 @@
 # https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
 {% macro tag_validation() %}
 
-{%- if target.name != "prod" -%}
+    {%- if target.name != "prod" -%}
 
-{% set data = namespace(all_tags=[]) %}
+        {% set data = namespace(all_tags=[]) %}
 
-{% for node in graph.nodes.values() %}
+        {% for node in graph.nodes.values() %}
 
-{% set tags = node.tags %} {% set data.all_tags = data.all_tags + tags %}
+            {% set tags = node.tags %} {% set data.all_tags = data.all_tags + tags %}
 
-{% endfor %}
+        {% endfor %}
 
-{% for source in graph.sources.values() %}
+        {% for source in graph.sources.values() %}
 
-{% set tags = source.tags %} {% set data.all_tags = data.all_tags + tags %}
+            {% set tags = source.tags %} {% set data.all_tags = data.all_tags + tags %}
 
-{% endfor %}
+        {% endfor %}
 
-{% set project_tags = data.all_tags | unique | sort | list %}
+        {% set project_tags = data.all_tags | unique | sort | list %}
 
-{% do log("Tags in Project: " ~ project_tags, info=true) %}
+        {% do log("Tags in Project: " ~ project_tags, info=true) %}
 
-{% set query %}
+        {% set query %}
             SELECT tag
             FROM {{ref('valid_tags')}}
-{% endset %}
+        {% endset %}
 
-{% set results = run_query(query) %}
+        {% set results = run_query(query) %}
 
-{% set valid_tags = results.columns[0].values() | sort | list %}
+        {% set valid_tags = results.columns[0].values() | sort | list %}
 
-{% do log("Tags in Validation File: " ~ valid_tags, info=true) %}
+        {% do log("Tags in Validation File: " ~ valid_tags, info=true) %}
 
-{% set error_message = namespace(errors=[]) %}
+        {% set error_message = namespace(errors=[]) %}
 
-{% for tag in project_tags %}
+        {% for tag in project_tags %}
 
-{% if tag not in valid_tags %}
-{% set error_message.errors = error_message.errors + [
-    "Tag '"
-    ~ tag
-    ~ "' is present in the project but not in the tag_validation seed file."
-] %}
-{% endif %}
+            {% if tag not in valid_tags %}
+                {% set error_message.errors = error_message.errors + [
+                    "Tag '"
+                    ~ tag
+                    ~ "' is present in the project but not in the tag_validation seed file."
+                ] %}
+            {% endif %}
 
-{% endfor %}
+        {% endfor %}
 
-{% for tag in valid_tags %}
+        {% for tag in valid_tags %}
 
-{% if tag not in project_tags %}
-{% set error_message.errors = error_message.errors + [
-    "Tag '"
-    ~ tag
-    ~ "' is present in the tag_validation seed file but not in project."
-] %}
-{% endif %}
+            {% if tag not in project_tags %}
+                {% set error_message.errors = error_message.errors + [
+                    "Tag '"
+                    ~ tag
+                    ~ "' is present in the tag_validation seed file but not in project."
+                ] %}
+            {% endif %}
 
-{% endfor %}
+        {% endfor %}
 
-{% if error_message.errors != [] %}
+        {% if error_message.errors != [] %}
 
-{% for message in error_message.errors %} {% do log(message, info=true) %} {% endfor %}
+            {% for message in error_message.errors %}
+                {% do log(message, info=true) %}
+            {% endfor %}
 
-{% do exceptions.warn("Tag Validation Error") %}
+            {% do exceptions.warn("Tag Validation Error") %}
 
-{% endif %}
+        {% endif %}
 
-{% endif %}
+    {% endif %}
 
 {% endmacro %}

--- a/tests/data/unformatted/205_rittman_hubspot_deals.sql
+++ b/tests/data/unformatted/205_rittman_hubspot_deals.sql
@@ -101,81 +101,95 @@ select * from joined
 # SEE:
 # https://github.com/rittmananalytics/ra_data_warehouse/blob/d8dc7bd1c008ca79f9d09c909734e28a66ef6366/LICENSE.txt
 {% if target.type == "bigquery" %}
-{% if var("marketing_warehouse_deal_sources") %}
-{% if "hubspot_crm" in var("marketing_warehouse_deal_sources") %}
-{% if var("stg_hubspot_crm_etl") == "fivetran" %}
+    {% if var("marketing_warehouse_deal_sources") %}
+        {% if "hubspot_crm" in var("marketing_warehouse_deal_sources") %}
+            {% if var("stg_hubspot_crm_etl") == "fivetran" %}
 
-with
-    source as (select * from {{ source("fivetran_hubspot_crm", "deals") }}),
-    hubspot_deal_company as (
-        select * from {{ source("fivetran_hubspot_crm", "deal_companies") }}
-    ),
-    hubspot_deal_pipelines_source as (
-        select * from {{ source("fivetran_hubspot_crm", "pipelines") }}
-    ),
-    hubspot_deal_property_history as (
-        select * from {{ source("fivetran_hubspot_crm", "property_history") }}
-    ),
-    hubspot_deal_stages as (
-        select * from {{ source("fivetran_hubspot_crm", "pipeline_stages") }}
-    ),
-    hubspot_deal_owners as (
-        select * from {{ source("fivetran_hubspot_crm", "owners") }}
-    ),
-    renamed as (
-        select
-            deal_id as deal_id,
-            property_dealname as deal_name,
-            property_dealtype as deal_type,
-            property_description as deal_description,
-            deal_pipeline_stage_id as deal_pipeline_stage_id,
-            deal_pipeline_id as deal_pipeline_id,
-            is_deleted as deal_is_deleted,
-            property_amount as deal_amount,
-            owner_id as deal_owner_id,
-            property_amount_in_home_currency as deal_amount_local_currency,
-            property_closed_lost_reason as deal_closed_lost_reason,
-            property_closedate as deal_closed_date,
-            property_createdate as deal_created_date,
-            property_hs_lastmodifieddate as deal_last_modified_date
-        from source
-    ),
-    joined as (
-        select
-            d.deal_id,
-            concat(
-                '{{ var(' stg_hubspot_crm_id - prefix ') }}',
-                cast(a.company_id as string)
-            ) as company_id,
-            d.* except (deal_id),
-            timestamp_millis(safe_cast(h.value as int64)) as deal_pipeline_stage_ts,
-            p.label as pipeline_label,
-            p.display_order as pipeline_display_order,
-            s.label as pipeline_stage_label,
-            s.display_order as pipeline_stage_display_order,
-            s.probability as pipeline_stage_close_probability_pct,
-            s.closed_won as pipeline_stage_closed_won,
-            concat(u.first_name, ' ', u.last_name) as owner_full_name,
-            u.email as owner_email
-        from renamed d
-        left outer join hubspot_deal_company a on d.deal_id = a.deal_id
-        left outer join
-            hubspot_deal_property_history h
-            on d.deal_id = h.deal_id
-            and h.name = concat('hs_date_entered_', d.deal_pipeline_stage_id)
-        join hubspot_deal_stages s on d.deal_pipeline_stage_id = s.stage_id
-        join hubspot_deal_pipelines_source p on s.pipeline_id = p.pipeline_id
-        left outer join
-            hubspot_deal_owners u on safe_cast(d.deal_owner_id as int64) = u.owner_id
-    )
-select *
-from joined
+                with
+                    source as (
+                        select * from {{ source("fivetran_hubspot_crm", "deals") }}
+                    ),
+                    hubspot_deal_company as (
+                        select *
+                        from {{ source("fivetran_hubspot_crm", "deal_companies") }}
+                    ),
+                    hubspot_deal_pipelines_source as (
+                        select * from {{ source("fivetran_hubspot_crm", "pipelines") }}
+                    ),
+                    hubspot_deal_property_history as (
+                        select *
+                        from {{ source("fivetran_hubspot_crm", "property_history") }}
+                    ),
+                    hubspot_deal_stages as (
+                        select *
+                        from {{ source("fivetran_hubspot_crm", "pipeline_stages") }}
+                    ),
+                    hubspot_deal_owners as (
+                        select * from {{ source("fivetran_hubspot_crm", "owners") }}
+                    ),
+                    renamed as (
+                        select
+                            deal_id as deal_id,
+                            property_dealname as deal_name,
+                            property_dealtype as deal_type,
+                            property_description as deal_description,
+                            deal_pipeline_stage_id as deal_pipeline_stage_id,
+                            deal_pipeline_id as deal_pipeline_id,
+                            is_deleted as deal_is_deleted,
+                            property_amount as deal_amount,
+                            owner_id as deal_owner_id,
+                            property_amount_in_home_currency
+                            as deal_amount_local_currency,
+                            property_closed_lost_reason as deal_closed_lost_reason,
+                            property_closedate as deal_closed_date,
+                            property_createdate as deal_created_date,
+                            property_hs_lastmodifieddate as deal_last_modified_date
+                        from source
+                    ),
+                    joined as (
+                        select
+                            d.deal_id,
+                            concat(
+                                '{{ var(' stg_hubspot_crm_id - prefix ') }}',
+                                cast(a.company_id as string)
+                            ) as company_id,
+                            d.* except (deal_id),
+                            timestamp_millis(
+                                safe_cast(h.value as int64)
+                            ) as deal_pipeline_stage_ts,
+                            p.label as pipeline_label,
+                            p.display_order as pipeline_display_order,
+                            s.label as pipeline_stage_label,
+                            s.display_order as pipeline_stage_display_order,
+                            s.probability as pipeline_stage_close_probability_pct,
+                            s.closed_won as pipeline_stage_closed_won,
+                            concat(u.first_name, ' ', u.last_name) as owner_full_name,
+                            u.email as owner_email
+                        from renamed d
+                        left outer join hubspot_deal_company a on d.deal_id = a.deal_id
+                        left outer join
+                            hubspot_deal_property_history h
+                            on d.deal_id = h.deal_id
+                            and h.name
+                            = concat('hs_date_entered_', d.deal_pipeline_stage_id)
+                        join
+                            hubspot_deal_stages s
+                            on d.deal_pipeline_stage_id = s.stage_id
+                        join
+                            hubspot_deal_pipelines_source p
+                            on s.pipeline_id = p.pipeline_id
+                        left outer join
+                            hubspot_deal_owners u
+                            on safe_cast(d.deal_owner_id as int64) = u.owner_id
+                    )
+                select *
+                from joined
 
-{% else %} {{ config(enabled=false) }}
-{% endif %}
-{% else %} {{ config(enabled=false) }}
-{% endif %}
-{% else %} {{ config(enabled=false) }}
-{% endif %}
+            {% else %} {{ config(enabled=false) }}
+            {% endif %}
+        {% else %} {{ config(enabled=false) }}
+        {% endif %}
+    {% else %} {{ config(enabled=false) }}
+    {% endif %}
 {% else %} {{ config(enabled=false) }}
 {% endif %}

--- a/tests/data/unformatted/207_rittman_int_journals.sql
+++ b/tests/data/unformatted/207_rittman_int_journals.sql
@@ -32,22 +32,22 @@ select * from journal_merge_list
 # https://github.com/rittmananalytics/ra_data_warehouse/blob/d8dc7bd1c008ca79f9d09c909734e28a66ef6366/LICENSE.txt
 {% if var("finance_warehouse_journal_sources") %}
 
-with
-    journal_merge_list as (
-        {% for source in var("finance_warehouse_journal_sources") %}
+    with
+        journal_merge_list as (
+            {% for source in var("finance_warehouse_journal_sources") %}
 
-        {% set relation_source = "stg_" + source + "_journals" %}
+                {% set relation_source = "stg_" + source + "_journals" %}
 
-        select '{{source}}' as source, *
-        from {{ ref(relation_source) }}
+                select '{{source}}' as source, *
+                from {{ ref(relation_source) }}
 
-        {% if not loop.last %}
-        union all
-        {% endif %}
-        {% endfor %}
-    )
-select *
-from journal_merge_list
+                {% if not loop.last %}
+                    union all
+                {% endif %}
+            {% endfor %}
+        )
+    select *
+    from journal_merge_list
 
 {% else %} {{ config(enabled=false) }}
 

--- a/tests/data/unformatted/208_rittman_int_plan_breakout_metrics.sql
+++ b/tests/data/unformatted/208_rittman_int_plan_breakout_metrics.sql
@@ -28,12 +28,12 @@ select * from plans_breakout_merge_list
 # https://github.com/rittmananalytics/ra_data_warehouse/blob/d8dc7bd1c008ca79f9d09c909734e28a66ef6366/LICENSE.txt
 {% if var("subscriptions_warehouse_sources") %}
 
-with
-    plans_breakout_merge_list as (
-        select * from {{ ref("stg_baremetrics_plan_breakout") }}
-    )
-select *
-from plans_breakout_merge_list
+    with
+        plans_breakout_merge_list as (
+            select * from {{ ref("stg_baremetrics_plan_breakout") }}
+        )
+    select *
+    from plans_breakout_merge_list
 
 {% else %} {{ config(enabled=false) }}
 

--- a/tests/data/unformatted/209_rittman_int_web_events_sessionized.sql
+++ b/tests/data/unformatted/209_rittman_int_web_events_sessionized.sql
@@ -184,10 +184,10 @@ from ordered_conversion_tagged
 # https://github.com/rittmananalytics/ra_data_warehouse/blob/d8dc7bd1c008ca79f9d09c909734e28a66ef6366/LICENSE.txt
 {% if var("product_warehouse_event_sources") %}
 
-with
-    events as (
-        select * from {{ ref("int_web_events") }}
-    /*  {% if is_incremental() %}
+    with
+        events as (
+            select * from {{ ref("int_web_events") }}
+        /*  {% if is_incremental() %}
     where visitor_id in (
         select distinct visitor_id
         from {{ref('int_web_events')}}
@@ -202,212 +202,214 @@ with
         )
     {% endif %}
 */
-    ),
+        ),
 
-    numbered as (
+        numbered as (
 
-        select
+            select
 
-            *,
+                *,
 
-            row_number() over (
-                partition by visitor_id order by event_ts
-            ) as event_number
+                row_number() over (
+                    partition by visitor_id order by event_ts
+                ) as event_number
 
-        from events
+            from events
 
-    ),
+        ),
 
-    lagged as (
+        lagged as (
 
-        select
+            select
 
-            *,
+                *,
 
-            lag(event_ts) over (
-                partition by visitor_id order by event_number
-            ) as previous_event_ts
+                lag(event_ts) over (
+                    partition by visitor_id order by event_number
+                ) as previous_event_ts
 
-        from numbered
+            from numbered
 
-    ),
+        ),
 
-    diffed as (
+        diffed as (
 
-        select
-            *,
-            {{ dbt_utils.datediff("event_ts", "previous_event_ts", "second") }}
-            as period_of_inactivity
+            select
+                *,
+                {{ dbt_utils.datediff("event_ts", "previous_event_ts", "second") }}
+                as period_of_inactivity
 
-        from lagged
+            from lagged
 
-    ),
+        ),
 
-    new_sessions as (
+        new_sessions as (
 
-        select
-            *,
-            case
-                when period_of_inactivity * -1 <= {{ var("web_inactivity_cutoff") }}
-                then 0
-                else 1
-            end as new_session
-        from diffed
+            select
+                *,
+                case
+                    when period_of_inactivity * -1 <= {{ var("web_inactivity_cutoff") }}
+                    then 0
+                    else 1
+                end as new_session
+            from diffed
 
-    ),
+        ),
 
-    session_numbers as (
+        session_numbers as (
 
-        select
+            select
 
-            *,
+                *,
 
-            sum(new_session) over (
-                partition by visitor_id
-                order by event_number
-                rows between unbounded preceding and current row
-            ) as session_number
+                sum(new_session) over (
+                    partition by visitor_id
+                    order by event_number
+                    rows between unbounded preceding and current row
+                ) as session_number
 
-        from new_sessions
+            from new_sessions
 
-    ),
+        ),
 
-    session_ids as (
+        session_ids as (
 
-        select
-            event_id,
-            event_type,
-            event_ts,
-            event_details,
-            page_title,
-            page_url_path,
-            referrer_host,
-            search,
-            page_url,
-            page_url_host,
-            gclid,
-            utm_term,
-            utm_content,
-            utm_medium,
-            utm_campaign,
-            utm_source,
-            ip,
-            visitor_id,
-            user_id,
-            device,
-            device_category,
-            event_number,
-            md5(
-                cast(
-                    concat(
-                        coalesce(cast(visitor_id as string), ''),
-                        '-',
-                        coalesce(cast(session_number as string), '')
-                    ) as string
-                )
-            ) as session_id,
-            site,
-            order_id,
-            total_revenue,
-            currency_code
-        from session_numbers
-    ),
-    id_stitching as (select * from {{ ref("int_web_events_user_stitching") }}),
-
-    joined as (
-
-        select
-
-            session_ids.*,
-
-            coalesce(id_stitching.user_id, session_ids.visitor_id) as blended_user_id
-
-        from session_ids
-        left join id_stitching on id_stitching.visitor_id = session_ids.visitor_id
-
-    ),
-    ordered as (
-        select
-            *,
-            row_number() over (
-                partition by blended_user_id order by event_ts
-            ) as event_seq,
-            row_number() over (
-                partition by blended_user_id, session_id order by event_ts
-            ) as event_in_session_seq,
-
-            case
-                when
-                    event_type = 'Page View'
-                    and session_id = lead(session_id, 1) over (
-                        partition by visitor_id order by event_number
+            select
+                event_id,
+                event_type,
+                event_ts,
+                event_details,
+                page_title,
+                page_url_path,
+                referrer_host,
+                search,
+                page_url,
+                page_url_host,
+                gclid,
+                utm_term,
+                utm_content,
+                utm_medium,
+                utm_campaign,
+                utm_source,
+                ip,
+                visitor_id,
+                user_id,
+                device,
+                device_category,
+                event_number,
+                md5(
+                    cast(
+                        concat(
+                            coalesce(cast(visitor_id as string), ''),
+                            '-',
+                            coalesce(cast(session_number as string), '')
+                        ) as string
                     )
-                then
-                    {{
-                        dbt_utils.datediff(
-                            "lead(event_ts,1) over (partition by visitor_id order by event_number)",
-                            "event_ts",
-                            "SECOND",
+                ) as session_id,
+                site,
+                order_id,
+                total_revenue,
+                currency_code
+            from session_numbers
+        ),
+        id_stitching as (select * from {{ ref("int_web_events_user_stitching") }}),
+
+        joined as (
+
+            select
+
+                session_ids.*,
+
+                coalesce(
+                    id_stitching.user_id, session_ids.visitor_id
+                ) as blended_user_id
+
+            from session_ids
+            left join id_stitching on id_stitching.visitor_id = session_ids.visitor_id
+
+        ),
+        ordered as (
+            select
+                *,
+                row_number() over (
+                    partition by blended_user_id order by event_ts
+                ) as event_seq,
+                row_number() over (
+                    partition by blended_user_id, session_id order by event_ts
+                ) as event_in_session_seq,
+
+                case
+                    when
+                        event_type = 'Page View'
+                        and session_id = lead(session_id, 1) over (
+                            partition by visitor_id order by event_number
                         )
-                    }}
-            end time_on_page_secs
-        from joined
+                    then
+                        {{
+                            dbt_utils.datediff(
+                                "lead(event_ts,1) over (partition by visitor_id order by event_number)",
+                                "event_ts",
+                                "SECOND",
+                            )
+                        }}
+                end time_on_page_secs
+            from joined
 
-    ),
-    ordered_conversion_tagged as (
-        select
-            o.*
-            {% if var("attribution_conversion_event_type") %}
-            ,
-            case
-                when
-                    o.event_type in (
-                        '{{ var(' attribution_conversion_event_type ') }}',
-                        '{{ var(' attribution_create_account_event_type ') }}'
-                    )
-                then
-                    lag(o.page_url, 1) over (
-                        partition by o.blended_user_id order by o.event_seq
-                    )
-            end as converting_page_url,
-            case
-                when
-                    o.event_type in (
-                        '{{ var(' attribution_conversion_event_type ') }}',
-                        '{{ var(' attribution_create_account_event_type ') }}'
-                    )
-                then
-                    lag(o.page_title, 1) over (
-                        partition by o.blended_user_id order by o.event_seq
-                    )
-            end as converting_page_title,
-            case
-                when
-                    o.event_type in (
-                        '{{ var(' attribution_conversion_event_type ') }}',
-                        '{{ var(' attribution_create_account_event_type ') }}'
-                    )
-                then
-                    lag(o.page_url, 2) over (
-                        partition by o.blended_user_id order by o.event_seq
-                    )
-            end as pre_converting_page_url,
-            case
-                when
-                    o.event_type in (
-                        '{{ var(' attribution_conversion_event_type ') }}',
-                        '{{ var(' attribution_create_account_event_type ') }}'
-                    )
-                then
-                    lag(o.page_title, 2) over (
-                        partition by o.blended_user_id order by o.event_seq
-                    )
-            end as pre_converting_page_title,
-            {% endif %}
-        from ordered o
-    )
-select *
-from ordered_conversion_tagged
+        ),
+        ordered_conversion_tagged as (
+            select
+                o.*
+                {% if var("attribution_conversion_event_type") %}
+                    ,
+                    case
+                        when
+                            o.event_type in (
+                                '{{ var(' attribution_conversion_event_type ') }}',
+                                '{{ var(' attribution_create_account_event_type ') }}'
+                            )
+                        then
+                            lag(o.page_url, 1) over (
+                                partition by o.blended_user_id order by o.event_seq
+                            )
+                    end as converting_page_url,
+                    case
+                        when
+                            o.event_type in (
+                                '{{ var(' attribution_conversion_event_type ') }}',
+                                '{{ var(' attribution_create_account_event_type ') }}'
+                            )
+                        then
+                            lag(o.page_title, 1) over (
+                                partition by o.blended_user_id order by o.event_seq
+                            )
+                    end as converting_page_title,
+                    case
+                        when
+                            o.event_type in (
+                                '{{ var(' attribution_conversion_event_type ') }}',
+                                '{{ var(' attribution_create_account_event_type ') }}'
+                            )
+                        then
+                            lag(o.page_url, 2) over (
+                                partition by o.blended_user_id order by o.event_seq
+                            )
+                    end as pre_converting_page_url,
+                    case
+                        when
+                            o.event_type in (
+                                '{{ var(' attribution_conversion_event_type ') }}',
+                                '{{ var(' attribution_create_account_event_type ') }}'
+                            )
+                        then
+                            lag(o.page_title, 2) over (
+                                partition by o.blended_user_id order by o.event_seq
+                            )
+                    end as pre_converting_page_title,
+                {% endif %}
+            from ordered o
+        )
+    select *
+    from ordered_conversion_tagged
 
 {% else %} {{ config(enabled=false) }}
 

--- a/tests/data/unformatted/214_get_unique_attributes.sql
+++ b/tests/data/unformatted/214_get_unique_attributes.sql
@@ -28,7 +28,7 @@
 {# Source: https://github.com/tconbeer/sqlfmt/issues/326 #}
 {% macro get_unique_attributes(source_table, node_col) %}
 
-{% set attribute_query %}
+    {% set attribute_query %}
     select
         distinct x.key as attributes
     from {{ source_table }} x
@@ -36,19 +36,19 @@
         and length(x.key) > 1 -- but keys of just '@' designate the node itself
         and regexp_count(x.path, '\\[') > 1 -- we don't need the attributes from the xml root node
         and not startswith(x.key, '@xmlns') -- we don't need attributed data about xml namespaces
-{% endset %}
+    {% endset %}
 
-{% set results = run_query(attribute_query) %}
+    {% set results = run_query(attribute_query) %}
 
-{% if execute %} {% set results_list = results.columns[0].values() %}
-{% else %} {% set results_list = [] %}
-{% endif %}
+    {% if execute %} {% set results_list = results.columns[0].values() %}
+    {% else %} {% set results_list = [] %}
+    {% endif %}
 
-{% for attribute in results_list %}
-,
-get({{ node_col }}, '{{ attribute }}')::varchar(
-    256
-) as attribute_{{ dbt_utils.slugify(attribute) | replace("@", "") }}
-{% endfor %}
+    {% for attribute in results_list %}
+        ,
+        get({{ node_col }}, '{{ attribute }}')::varchar(
+            256
+        ) as attribute_{{ dbt_utils.slugify(attribute) | replace("@", "") }}
+    {% endfor %}
 
 {% endmacro %}

--- a/tests/data/unformatted/215_gitlab_get_backup_table_command.sql
+++ b/tests/data/unformatted/215_gitlab_get_backup_table_command.sql
@@ -20,9 +20,9 @@
 # https://github.com/tconbeer/gitlab-analytics-sqlfmt/blob/9360d2f1986c37615926b0416e8d0fb23cae3e6e/LICENSE
 {% macro get_backup_table_command(table, day_of_month) %}
 
-{% set backup_key -%}
+    {% set backup_key -%}
         day_{{ day_of_month }}/{{ table.database.lower() }}/{{ table.schema.lower() }}/{{ table.name.lower() }}/data_
-{%- endset %}
+    {%- endset %}
 
     copy into @raw.public.backup_stage/{{ backup_key }}
     from {{ table.database }}.{{ table.schema }}."{{ table.name.upper() }}"

--- a/tests/data/unformatted/217_dbt_unit_testing_csv.sql
+++ b/tests/data/unformatted/217_dbt_unit_testing_csv.sql
@@ -73,27 +73,27 @@
     "should sum order values to calculate customer_lifetime_value"
 ) %}
 
-{% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
     customer_id, first_name, last_name
     1,'',''
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
     order_id,customer_id,order_date
     1001,1,null
     1002,1,null
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
     order_id,amount
     1001,10
     1002,10
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    {% call dbt_unit_testing.expect({"input_format": "csv"}) %}
     customer_id,customer_lifetime_value
     1,20
-{% endcall %}
+    {% endcall %}
 {% endcall %}
 
 {% call dbt_unit_testing.test(
@@ -101,45 +101,45 @@
     "should sum order values to calculate customer_lifetime_value"
 ) %}
 
-{% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_customers", {"input_format": "csv"}) %}
     customer_id | first_name | last_name
     1           | ''         | ''
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_orders", {"input_format": "csv"}) %}
     order_id | customer_id | order_date 
     1        | 1           | null
     2        | 1           | null
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
+    {% call dbt_unit_testing.mock_ref("stg_payments", {"input_format": "csv"}) %}
     order_id | amount
     1        | 10
     2        | 10
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.expect({"input_format": "csv"}) %}
+    {% call dbt_unit_testing.expect({"input_format": "csv"}) %}
     customer_id | customer_lifetime_value
     1           | 20
-{% endcall %}
+    {% endcall %}
 {% endcall %}
 
 {% call dbt_unit_testing.test("customers", "should show customer_id without orders") %}
-{% call dbt_unit_testing.mock_ref("stg_customers") %}
+    {% call dbt_unit_testing.mock_ref("stg_customers") %}
     select 1 as customer_id, '' as first_name, '' as last_name
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_orders") %}
+    {% call dbt_unit_testing.mock_ref("stg_orders") %}
     select null::numeric as customer_id, null::numeric as order_id, null as order_date  
     where false
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.mock_ref("stg_payments") %}
+    {% call dbt_unit_testing.mock_ref("stg_payments") %}
      select null::numeric as order_id, null::numeric as amount 
      where false
-{% endcall %}
+    {% endcall %}
 
-{% call dbt_unit_testing.expect() %}
+    {% call dbt_unit_testing.expect() %}
     select 1 as customer_id
-{% endcall %}
+    {% endcall %}
 {% endcall %}

--- a/tests/unit_tests/test_formatter.py
+++ b/tests/unit_tests/test_formatter.py
@@ -59,7 +59,7 @@ def test_remove_extra_blank_lines(default_mode: Mode) -> None:
     expected_string = (
         "select 1\n;\n\n\n"
         "select\n    1,\n\n    2\n;\n"
-        "{% macro foo() %}\n\nfoo\n{% endmacro %}\n"
+        "{% macro foo() %}\n\n    foo\n{% endmacro %}\n"
     )
     raw_query = formatter.mode.dialect.initialize_analyzer(
         formatter.mode.line_length

--- a/tests/unit_tests/test_jinjafmt.py
+++ b/tests/unit_tests/test_jinjafmt.py
@@ -67,7 +67,7 @@ def uninstall_black(monkeypatch: pytest.MonkeyPatch) -> None:
     ],
 )
 def test_jinja_tag_from_string(tag: str, result: Tuple[str, str, str, str]) -> None:
-    assert JinjaTag.from_string(tag, 0) == JinjaTag(tag, *result, 0)
+    assert JinjaTag.from_string(tag, (0, 0)) == JinjaTag(tag, *result, (0, 0))
 
 
 @pytest.mark.parametrize(
@@ -261,8 +261,11 @@ def test_black_wrapper_format_string_invalid_input(
 @pytest.mark.parametrize(
     "tag,expected",
     [
-        (JinjaTag("{{ any code! }}", "{{", "", "any code!", "}}", 0), 88 - 2 - 2 - 2),
-        (JinjaTag("{%- set _ %}", "{%-", "set", "_", "%}", 0), 88 - 3 - 3 - 2 - 2),
+        (
+            JinjaTag("{{ any code! }}", "{{", "", "any code!", "}}", (0, 0)),
+            88 - 2 - 2 - 2,
+        ),
+        (JinjaTag("{%- set _ %}", "{%-", "set", "_", "%}", (0, 0)), 88 - 3 - 3 - 2 - 2),
     ],
 )
 def test_max_code_length(tag: JinjaTag, expected: int) -> None:
@@ -316,7 +319,7 @@ def test_preprocess_string_properties(
 def test_jinja_tag_remove_trailing_comma(
     source_string: str, expected_count: int, is_def: bool
 ) -> None:
-    tag = JinjaTag.from_string(source_string=source_string, depth=0)
+    tag = JinjaTag.from_string(source_string=source_string, depth=(0, 0))
     assert tag.is_macro_like_def == is_def
     tag.is_blackened = True
     result = str(tag)


### PR DESCRIPTION
closes #403 

This represents a major update to the sqlfmt style. From the CHANGELOG:

-   the contents of jinja blocks are now indented if the block wraps onto multiple rows ([#403](https://github.com/tconbeer/sqlfmt/issues/403)). This is now the proper sqlfmt style:
    ```sql
    select
        some_field,
        {% for some_item in some_sequence %}
            some_function({{ some_item }}){% if not loop.last %}, {% endif %}
        {% endfor %}
    ```
    While in this simple example the new style makes it less clear that `some_field` and `some_function` are at the same SQL depth, the formatting of complex files with nested jinja blocks is much improved. For example:

    ```sql
    {%- for col in cols -%}
        {%- if col.column.lower() not in remove | map(
            "lower"
        ) and col.column.lower() not in exclude | map("lower") -%}
            {% do include_cols.append(col) %}
        {%- endif %}
    {%- endfor %}
    ```
    See also [this discussion](https://github.com/tconbeer/sqlfmt/discussions/317).