### PR TITLE
fix #431: evaluate exclude paths as absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   Relative `exclude` paths defined in `pyproject.toml` files are now evaluated relative to the location of the file, not the current working directory.
+    Relative paths provided to the `--exclude` option (or env var) are evaluated relative to the current working directory. Files and exclude paths
+    are now compared as resolved, absolute paths. (Fixes [#431](https://github.com/tconbeer/sqlfmt/issues/431) - thank you [@cmcnicoll](https://github.com/cmcnicoll)!)
 -   sqlfmt now supports the `<=>` operator ([#432](https://github.com/tconbeer/sqlfmt/issues/432) - thank you [@kathykwon](https://github.com/kathykwon)!)
 
 ## [0.18.3] - 2023-05-31
 
+### Bug Fixes
+
 -   fixes a bug where multiple c-style comments (e.g., `/* comment */`) on a single line would cause sqlfmt
     to not include all comments in formatted output ([#419](https://github.com/tconbeer/sqlfmt/issues/419) - thank you [@aersam](https://github.com/aersam)!)
+
+### Features
+
 -   adds a safety check to ensure comments are preserved in formatted output
 
 ## [0.18.2] - 2023-05-31

--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -97,8 +97,13 @@ def get_matching_paths(paths: Iterable[Path], mode: Mode) -> Set[Path]:
 
     if mode.exclude:
         globs = []
-        for pn in mode.exclude:
-            globs.extend(glob(pn, recursive=True))
+        for p in [Path(s) for s in mode.exclude]:
+            if not p.is_absolute() and mode.exclude_root is not None:
+                p = mode.exclude_root / p
+                p = p.resolve()
+            elif not p.is_absolute():
+                p = p.resolve()
+            globs.extend(glob(str(p), recursive=True))
         exclude_set = {Path(s) for s in globs}
     else:
         exclude_set = set()
@@ -135,7 +140,7 @@ def initialize_progress_bar(
 
 def _get_included_paths(paths: Iterable[Path], mode: Mode) -> Set[Path]:
     """
-    Takes a list of paths (files or directories) and a mode as an input, and
+    Takes a list of absolute paths (files or directories) and a mode as an input, and
     yields paths to individual files that match the input paths (or are contained in
     its directories)
     """

--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -155,7 +155,7 @@ from sqlfmt.mode import Mode
 @click.argument(
     "files",
     nargs=-1,
-    type=click.Path(exists=True, allow_dash=True, path_type=Path),
+    type=click.Path(exists=True, allow_dash=True, resolve_path=True, path_type=Path),
 )
 @click.pass_context
 def sqlfmt(

--- a/src/sqlfmt/config.py
+++ b/src/sqlfmt/config.py
@@ -53,7 +53,7 @@ def _get_common_parents(files: List[Path]) -> List[Path]:
         root_dir = max(common_parents, key=lambda p: p.parts)
     except ValueError:
         # if there are no common parents (e.g., stdin), just use the cwd
-        root_dir = Path(".").resolve()
+        root_dir = Path.cwd()
     search_paths = [root_dir, *root_dir.parents]
     return search_paths
 

--- a/src/sqlfmt/config.py
+++ b/src/sqlfmt/config.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set, Union
 
 from sqlfmt.exception import SqlfmtConfigError
 from sqlfmt.mode import Mode
+from sqlfmt.report import STDIN_PATH
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -11,7 +12,7 @@ else:
     import tomli as tomllib
 
 
-Config = Dict[str, Union[bool, int, List[str], str]]
+Config = Dict[str, Union[bool, int, List[str], str, Path]]
 
 
 def load_config_file(files: List[Path]) -> Config:
@@ -28,23 +29,31 @@ def load_config_file(files: List[Path]) -> Config:
 
 def _get_common_parents(files: List[Path]) -> List[Path]:
     """
-    For a list of files, returns a Set of paths for all
+    For a list of absolute paths, returns a Set of paths for all
     of the common parents of files
     """
     assert files, "Must provide a list of paths"
     common_parents: Set[Path] = set()
     for p in files:
-        parents = set(p.absolute().parents)
-        if p.is_dir():
-            parents.add(p)
-        if not common_parents:
-            common_parents = parents
+        if p == STDIN_PATH:
+            break
         else:
-            common_parents &= parents
+            assert p.is_absolute()
+            parents = set(p.parents)
+            if p.is_dir():
+                parents.add(p)
+            if not common_parents:
+                common_parents = parents
+            else:
+                common_parents &= parents
 
     # the root directory is the lowest (i.e. most specific)
     # common parent among all of the files passed to sqlfmt
-    root_dir = max(common_parents, key=lambda p: p.parts)
+    try:
+        root_dir = max(common_parents, key=lambda p: p.parts)
+    except ValueError:
+        # if there are no common parents (e.g., stdin), just use the cwd
+        root_dir = Path(".").resolve()
     search_paths = [root_dir, *root_dir.parents]
     return search_paths
 
@@ -85,6 +94,8 @@ def _load_config_from_path(config_path: Optional[Path]) -> Config:
                 f"Check for invalid TOML. {e}"
             )
         raw_config: Config = pyproject_dict.get("tool", {}).get("sqlfmt", {})
+        if "exclude" in raw_config and "exclude_root" not in raw_config:
+            raw_config["exclude_root"] = config_path.parent
         return _validate_config(raw_config)
 
 

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -1,6 +1,7 @@
 import os
 from dataclasses import dataclass, field
-from typing import List
+from pathlib import Path
+from typing import List, Optional
 
 from sqlfmt.dialect import ClickHouse, Polyglot
 from sqlfmt.exception import SqlfmtConfigError
@@ -19,6 +20,7 @@ class Mode:
     check: bool = False
     diff: bool = False
     exclude: List[str] = field(default_factory=list)
+    exclude_root: Optional[Path] = None
     encoding: str = "utf-8"
     fast: bool = False
     single_process: bool = False
@@ -31,12 +33,13 @@ class Mode:
     force_color: bool = False
 
     def __post_init__(self) -> None:
-        options = {
-            "polyglot": Polyglot(),
-            "clickhouse": ClickHouse(),
+        # get the dialect from its name.
+        dialects = {
+            "polyglot": Polyglot,
+            "clickhouse": ClickHouse,
         }
         try:
-            self.dialect = options[self.dialect_name.lower()]
+            self.dialect = dialects[self.dialect_name.lower()]()
         except KeyError:
             raise SqlfmtConfigError(
                 f"Mode was created with dialect_name={self.dialect_name}, "

--- a/src/sqlfmt/report.py
+++ b/src/sqlfmt/report.py
@@ -52,6 +52,13 @@ class SqlFormatResult:
     exception: Optional[SqlfmtError] = None
     from_cache: bool = False
 
+    def __post_init__(self) -> None:
+        cwd = Path(".").resolve()
+        try:
+            self.display_path = self.source_path.relative_to(cwd)
+        except ValueError:
+            self.display_path = self.source_path
+
     def maybe_print_to_stdout(self) -> None:
         """
         If sqlfmt received a query via stdin, print the formatted string to stdout
@@ -105,15 +112,15 @@ class Report:
         report.append(f"{self._pluralize_file(self.number_unchanged)} {unchanged}.")
         for res in self.errored_results[0:50]:
             err = style_output(str(res.exception), fg="red")
-            report.append(f"{res.source_path}\n    {err}")
+            report.append(f"{res.display_path}\n    {err}")
         if not self.mode.quiet or self.mode.diff:
             for res in self.changed_results:
-                report.append(f"{res.source_path} {formatted}.")
+                report.append(f"{res.display_path} {formatted}.")
                 if self.mode.diff:
                     report.append(self._generate_diff(res))
         if self.mode.verbose:
             for res in self.unchanged_results:
-                report.append(f"{res.source_path} {unchanged}.")
+                report.append(f"{res.display_path} {unchanged}.")
 
         msg = "\n".join(report)
         if self.mode.color is False:

--- a/src/sqlfmt/report.py
+++ b/src/sqlfmt/report.py
@@ -53,9 +53,8 @@ class SqlFormatResult:
     from_cache: bool = False
 
     def __post_init__(self) -> None:
-        cwd = Path(".").resolve()
         try:
-            self.display_path = self.source_path.relative_to(cwd)
+            self.display_path = self.source_path.relative_to(Path.cwd())
         except ValueError:
             self.display_path = self.source_path
 

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -85,6 +85,15 @@ def test_file_discovery_with_excludes(
     assert res == sql_jinja_files
 
 
+def test_file_discovery_with_abs_excludes(
+    file_discovery_dir: Path, sql_jinja_files: Set[Path]
+) -> None:
+    exclude = [str(file_discovery_dir / "**/*.sql")]
+    mode = Mode(exclude=exclude, exclude_root=None)
+    res = get_matching_paths(file_discovery_dir.iterdir(), mode)
+    assert res == sql_jinja_files
+
+
 def test_file_discovery_with_excludes_no_root(
     file_discovery_dir: Path, all_files: Set[Path], sql_jinja_files: Set[Path]
 ) -> None:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any, List
 
@@ -64,29 +63,6 @@ def test_find_config_file_not_in_tree(
     assert config_path is None
 
 
-def test_find_config_file_relative_and_absolute(
-    tmp_path: Path, files_relpath: List[Path]
-) -> None:
-    # Only check the cases where we are providing more than one path
-    if len(files_relpath) == 1:
-        return
-
-    current_dir = os.getcwd()
-    copy_config_file_to_dst("valid_sqlfmt_config.toml", tmp_path)
-
-    try:
-        os.chdir(tmp_path)
-
-        files = [tmp_path / files_relpath[0], files_relpath[1]]
-        search_paths = _get_common_parents(files)
-        assert tmp_path in search_paths
-        config_path = _find_config_file(search_paths)
-        assert config_path
-        assert config_path == tmp_path / "pyproject.toml"
-    finally:
-        os.chdir(current_dir)
-
-
 def test_load_config_from_path(tmp_path: Path) -> None:
     copy_config_file_to_dst("valid_sqlfmt_config.toml", tmp_path)
     config = _load_config_from_path(tmp_path / "pyproject.toml")
@@ -94,6 +70,7 @@ def test_load_config_from_path(tmp_path: Path) -> None:
     assert config["line_length"] == 100
     assert config["check"] is True
     assert config.get("name", "does not exist") == "does not exist"
+    assert config.get("exclude_root", "does not exist") == "does not exist"
 
 
 def test_load_config_from_path_minimal_config(tmp_path: Path) -> None:
@@ -101,6 +78,7 @@ def test_load_config_from_path_minimal_config(tmp_path: Path) -> None:
     config = _load_config_from_path(tmp_path / "pyproject.toml")
     assert config
     assert config["exclude"] == ["target/**/*", "dbt_packages/**/*"]
+    assert config["exclude_root"] == tmp_path
 
 
 def test_load_config_from_path_invalid_toml(tmp_path: Path) -> None:


### PR DESCRIPTION
This reverts some of the changes in #427 , relying instead on click's path resolution.

To make apples-to-apples comparisons, we also have to resolve the exclude globs, and do that relative to the config file, if they are defined there. This defines previously undefined behavior about the exclude option in config files.