### PR TITLE
fix #457: Make `--exclude` option follow symlinked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   Fixes a bug where `--exclude` would not follow symlinks when globbing
+    ([#457](https://github.com/tconbeer/sqlfmt/issues/457) - thank you [@jeancochrane](https://github.com/jeancochrane)!).
+
 ## [0.19.1] - 2023-07-13
 
 ### Bug Fixes

--- a/tests/data/unit_tests/test_api/test_file_discovery/a_directory/symlink_target_directory
+++ b/tests/data/unit_tests/test_api/test_file_discovery/a_directory/symlink_target_directory
@@ -1,0 +1,1 @@
+symlink_source_directory

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -50,6 +50,8 @@ def all_files(file_discovery_dir: Path) -> Set[Path]:
         p / "a_directory/one_file.sql",
         p / "a_directory/nested_directory/another_file.sql",
         p / "a_directory/nested_directory/j2_extension.sql.jinja",
+        p / "a_directory/symlink_source_directory/symlink_file.sql",
+        p / "a_directory/symlink_target_directory/symlink_file.sql",
     }
     return files
 
@@ -74,7 +76,12 @@ def test_file_discovery(
     [
         ["**/*_file*"],
         ["**/*.sql"],
-        ["**/top*", "**/a_directory/*", "**/a_directory/**/another_file.sql"],
+        [
+            "**/top*",
+            "**/a_directory/*",
+            "**/a_directory/**/another_file.sql",
+            "**/a_directory/**/symlink_file.sql",
+        ],
     ],
 )
 def test_file_discovery_with_excludes(


### PR DESCRIPTION
This PR updates the globbing behavior for the `--exclude` option in `api.get_matching_paths()` to rely only on `glob.glob()` instead of `Path.glob()`, the latter of which contains a bug on Python <3.13 such that it [does not always follow symlinked directories correctly](https://github.com/tconbeer/sqlfmt/issues/457).