### PR TITLE
fix/#600/jinja multiline string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Fixes a bug where complex python statements inside of jinja tags could cause unstable formatting ([#600](https://github.com/tconbeer/sqlfmt/issues/600) - thank you [@nenkie76](https://github.com/nenkie76)!)
+
 ## [0.23.1] - 2024-07-26
 
 ### Bug Fixes

--- a/src/sqlfmt/jinjafmt.py
+++ b/src/sqlfmt/jinjafmt.py
@@ -271,9 +271,8 @@ class JinjaTag:
             extra_indent = " " * 4
 
         for i, code_line in enumerate(code_lines, start=1 if self.verb else 0):
-            lines.append(
-                f"{indent}{'' if i in no_indent_lines else extra_indent}{code_line}"
-            )
+            line_indent = "" if i in no_indent_lines else f"{indent}{extra_indent}"
+            lines.append(f"{line_indent}{code_line}")
 
         if self.verb:
             lines[-1] = f"{indent}{lines[-1].lstrip()} {self.closing_marker}"
@@ -287,7 +286,7 @@ class JinjaTag:
 
     def _find_multiline_python_str_lines(self) -> MutableSet[int]:
         try:
-            tree = ast.parse(self.code, mode="eval")
+            tree = ast.parse(self.code, mode="exec")
         except SyntaxError:
             # this jinja isn't quite python, so give up here.
             return set()

--- a/tests/data/preformatted/303_jinjafmt_more_mutliline_str.sql
+++ b/tests/data/preformatted/303_jinjafmt_more_mutliline_str.sql
@@ -9,5 +9,10 @@
         column_b1,
         column_b2,
         """,
+        "c": (
+            "foooooooooooooooooooo,\n"
+            "barrrrrrrrrrrrrrrrrrr,\n"
+            "bazzzzzzzzzzzzzzzzzzz,\n"
+        ),
     } %}
 {% endmacro %}

--- a/tests/data/preformatted/303_jinjafmt_more_mutliline_str.sql
+++ b/tests/data/preformatted/303_jinjafmt_more_mutliline_str.sql
@@ -1,0 +1,13 @@
+{% macro test(key) %}
+    {% set columns_by_source = {
+        "a": """
+        column_a1,
+        column_a2,
+        column_a3,
+        """,
+        "b": """
+        column_b1,
+        column_b2,
+        """,
+    } %}
+{% endmacro %}

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -18,6 +18,7 @@ from tests.util import check_formatting, read_test_data
         "preformatted/008_reserved_names.sql",
         "preformatted/301_multiline_jinjafmt.sql",
         "preformatted/302_jinjafmt_multiline_str.sql",
+        "preformatted/303_jinjafmt_more_mutliline_str.sql",
         "preformatted/400_create_table.sql",
         "unformatted/100_select_case.sql",
         "unformatted/101_multiline.sql",


### PR DESCRIPTION
- **fix #600: improve detection of python multiline strings**
- **chore: update changelog**
- **fix: also fix case using tuple concat strings**
