### PR TITLE
Issue #628 do not split comments with jinja tags

### DIFF
--- a/src/sqlfmt/comment.py
+++ b/src/sqlfmt/comment.py
@@ -153,6 +153,9 @@ class Comment:
         """
         if len(text) < max_length:
             yield text.rstrip()
+        elif re.match(r".*({{.*?}}|{%.*?%}).*", text):
+            # jinja comments are not split
+            yield text.rstrip()
         else:
             for idx, char in enumerate(reversed(text[:max_length])):
                 if char.isspace():

--- a/tests/data/unformatted/127_more_comments.sql
+++ b/tests/data/unformatted/127_more_comments.sql
@@ -1,4 +1,6 @@
 -- source: https://github.com/tconbeer/sqlfmt/issues/348
+-- source: https://github.com/tconbeer/sqlfmt/issues/628
+-- depends_on: {{ ref('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx') }}
 with table_a as (
     select
         /* Notice that this select statement can fit on a single line without comments */
@@ -26,6 +28,8 @@ select 1
 , 4 -- four inline
 )))))__SQLFMT_OUTPUT__(((((
 -- source: https://github.com/tconbeer/sqlfmt/issues/348
+-- source: https://github.com/tconbeer/sqlfmt/issues/628
+-- depends_on: {{ ref('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx') }}
 with
     table_a as (
         select


### PR DESCRIPTION
Prevent splitting of comments that contain Jinja tags as outlined in #628 
Add test to make sure does not split that comment.