### PR TITLE
feat: Add option allowing the "newline before semicolon" behavior to be disabled

### DIFF
--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -140,6 +140,15 @@ from sqlfmt.mode import Mode
     ),
 )
 @click.option(
+    "--new-line-before-semicolon/--no-new-line-before-semicolon",
+    envvar="SQLFMT_NEW_LINE_BEFORE_SEMICOLON",
+    is_flag=True,
+    default=True,
+    help=(
+        "Whether to add a newline before semicolons. Defaults to true."
+    )
+)
+@click.option(
     "-d",
     "--dialect",
     "dialect_name",

--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -140,13 +140,11 @@ from sqlfmt.mode import Mode
     ),
 )
 @click.option(
-    "--new-line-before-semicolon/--no-new-line-before-semicolon",
-    envvar="SQLFMT_NEW_LINE_BEFORE_SEMICOLON",
+    "--newline-before-semicolon/--no-newline-before-semicolon",
+    envvar="SQLFMT_NEWLINE_BEFORE_SEMICOLON",
     is_flag=True,
     default=True,
-    help=(
-        "Whether to add a newline before semicolons. Defaults to true."
-    )
+    help=("Whether to add a newline before semicolons. Defaults to true."),
 )
 @click.option(
     "-d",

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -31,6 +31,7 @@ class Mode:
     no_progressbar: bool = False
     no_color: bool = False
     force_color: bool = False
+    new_line_before_semicolon: bool = True
 
     def __post_init__(self) -> None:
         # get the dialect from its name.

--- a/src/sqlfmt/mode.py
+++ b/src/sqlfmt/mode.py
@@ -31,7 +31,7 @@ class Mode:
     no_progressbar: bool = False
     no_color: bool = False
     force_color: bool = False
-    new_line_before_semicolon: bool = True
+    newline_before_semicolon: bool = True
 
     def __post_init__(self) -> None:
         # get the dialect from its name.

--- a/src/sqlfmt/node.py
+++ b/src/sqlfmt/node.py
@@ -110,6 +110,10 @@ class Node:
     @property
     def divides_queries(self) -> bool:
         return self.token.type.divides_queries
+    
+    @property
+    def is_semicolon(self) -> bool:
+        return self.token.type is TokenType.SEMICOLON
 
     @property
     def is_opening_bracket(self) -> bool:

--- a/src/sqlfmt/query_formatter.py
+++ b/src/sqlfmt/query_formatter.py
@@ -21,7 +21,7 @@ class QueryFormatter:
         apparent
         """
         node_manager = NodeManager(self.mode.dialect.case_sensitive_names)
-        splitter = LineSplitter(node_manager, self.mode.new_line_before_semicolon)
+        splitter = LineSplitter(node_manager, self.mode.newline_before_semicolon)
         new_lines = []
         for line in lines:
             splits = list(splitter.maybe_split(line))

--- a/src/sqlfmt/query_formatter.py
+++ b/src/sqlfmt/query_formatter.py
@@ -21,7 +21,7 @@ class QueryFormatter:
         apparent
         """
         node_manager = NodeManager(self.mode.dialect.case_sensitive_names)
-        splitter = LineSplitter(node_manager)
+        splitter = LineSplitter(node_manager, self.mode.new_line_before_semicolon)
         new_lines = []
         for line in lines:
             splits = list(splitter.maybe_split(line))

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -10,6 +10,7 @@ from sqlfmt.node_manager import NodeManager
 @dataclass
 class LineSplitter:
     node_manager: NodeManager
+    new_line_before_semicolon: bool = True
 
     def maybe_split(self, line: Line) -> List[Line]:
         """
@@ -78,7 +79,7 @@ class LineSplitter:
             or node.is_closing_bracket
             or node.is_closing_jinja_block
             # always split before a node that divides queries
-            or node.divides_queries
+            or (node.divides_queries and (self.new_line_before_semicolon or not node.is_semicolon))
         ):
             return True
         # split if an opening bracket immediately follows

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -36,9 +36,9 @@ class LineSplitter:
                     new_line, comments = self.split_at_index(
                         line, head, i, comments, no_tail=True
                     )
-                    assert not comments, (
-                        "Comments must be empty here or we'll drop them"
-                    )
+                    assert (
+                        not comments
+                    ), "Comments must be empty here or we'll drop them"
                     new_lines.append(new_line)
                 return new_lines
             elif (
@@ -79,8 +79,11 @@ class LineSplitter:
             or node.is_closing_bracket
             or node.is_closing_jinja_block
             # always split before a node that divides queries
-            or (node.divides_queries and (self.new_line_before_semicolon or not node.is_semicolon))
+            or node.divides_queries
         ):
+            if not self.new_line_before_semicolon and node.is_semicolon:
+                return False
+
             return True
         # split if an opening bracket immediately follows
         # a closing bracket

--- a/src/sqlfmt/splitter.py
+++ b/src/sqlfmt/splitter.py
@@ -10,7 +10,7 @@ from sqlfmt.node_manager import NodeManager
 @dataclass
 class LineSplitter:
     node_manager: NodeManager
-    new_line_before_semicolon: bool = True
+    newline_before_semicolon: bool = True
 
     def maybe_split(self, line: Line) -> List[Line]:
         """
@@ -81,7 +81,7 @@ class LineSplitter:
             # always split before a node that divides queries
             or node.divides_queries
         ):
-            if not self.new_line_before_semicolon and node.is_semicolon:
+            if not self.newline_before_semicolon and node.is_semicolon:
                 return False
 
             return True

--- a/src/sqlfmt/tokens.py
+++ b/src/sqlfmt/tokens.py
@@ -98,6 +98,7 @@ class TokenType(Enum):
             TokenType.COMMA,
             TokenType.DOT,
             TokenType.NEWLINE,
+            TokenType.SEMICOLON,
         ]
 
     @cached_property


### PR DESCRIPTION
This commit adds the `newline_before_semicolon` option, which defaults to True (to maintain current behavior). If set to False, it should disable the behavior adding newlines before semicolons.

This is helpful for applications (like DDL) where there are a lot of separate statements, resulting in a lot of clutter from this rule.