### PR TITLE
feat: add support for global config flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- sqlfmt now accepts a path to a `pyproject.toml` file as an argument. To leverage this pass `--config <path to file>`. If passed, sqlfmt will not attempt to find a config file. The file must exist or an exception will be thrown. Note that other options pased at the command line will override the settings within this file.
+
 ## [0.26.0] - 2025-01-27
 
 ### Formatting Changes and Bug Fixes

--- a/src/sqlfmt/cli.py
+++ b/src/sqlfmt/cli.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 import click
 
@@ -152,6 +152,18 @@ from sqlfmt.mode import Mode
         "case sensitivity in function, field, and alias names."
     ),
 )
+@click.option(
+    "--config",
+    "config_path",
+    envvar="SQLFMT_CONFIG",
+    type=click.Path(
+        exists=True, dir_okay=False, allow_dash=False, resolve_path=True, path_type=Path
+    ),
+    help=(
+        "A path to a `pyproject.toml` file. Options passed at the command line will "
+        "override settings in this file."
+    ),
+)
 @click.argument(
     "files",
     nargs=-1,
@@ -159,7 +171,10 @@ from sqlfmt.mode import Mode
 )
 @click.pass_context
 def sqlfmt(
-    ctx: click.Context, files: List[Path], **kwargs: Union[bool, int, List[str], str]
+    ctx: click.Context,
+    files: List[Path],
+    config_path: Optional[Path] = None,
+    **kwargs: Union[bool, int, List[str], str],
 ) -> None:
     """
     sqlfmt formats your dbt SQL files so you don't have to.
@@ -173,7 +188,7 @@ def sqlfmt(
     https://sqlfmt.com for documentation and more information.
     """
     if files:
-        config = load_config_file(files)
+        config = load_config_file(files, config_path)
         non_default_options = {
             k: v
             for k, v in kwargs.items()

--- a/src/sqlfmt/config.py
+++ b/src/sqlfmt/config.py
@@ -15,14 +15,19 @@ else:
 Config = Dict[str, Union[bool, int, List[str], str, Path]]
 
 
-def load_config_file(files: List[Path]) -> Config:
+def load_config_file(files: List[Path], config_path: Optional[Path]) -> Config:
     """
     files is a list of resolved, absolute paths (like the ones passed from the
     Click CLI). This finds a pyproject.toml file in the common parent directory
     of files (or in the common parent's parents).
+
+    If config_path is provided, searching for a config via files will be skipped
+    entirely.
     """
-    common_parents = _get_common_parents(files)
-    config_path = _find_config_file(common_parents)
+    if config_path is None:
+        common_parents = _get_common_parents(files)
+        config_path = _find_config_file(common_parents)
+
     config = _load_config_from_path(config_path)
     return config
 


### PR DESCRIPTION
Pass `--config` to manually set a config file. I've opted to assert that this file exists and skip any searching for a pyproject.toml otherwise. You can also set the config file via the `SQLFMT_CONFIG` env var.

Closes: https://github.com/tconbeer/sqlfmt/issues/671