### PR TITLE
fix: treat METADATA$FILENAME and related Snowflake metadata columns as single tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes and Bug Fixes
+
+- sqlfmt now correctly lexes Snowflake metadata columns like `METADATA$FILENAME` as single tokens, rather than splitting on the `$`.
+
 ## [0.29.0] - 2026-01-12
 
 ## Breaking changes

--- a/src/sqlfmt/rules/core.py
+++ b/src/sqlfmt/rules/core.py
@@ -174,6 +174,7 @@ CORE = [
         priority=600,
         pattern=group(
             r"@\w+",  # stages
+            r"(?i:metadata)\$\w+",  # Snowflake metadata columns
             r"\$\d+",  # pg placeholders
             r"\$\w+",  # variables
             r"%(\([^%()]+\))?s",  # psycopg placeholders

--- a/src/sqlfmt/rules/core.py
+++ b/src/sqlfmt/rules/core.py
@@ -174,7 +174,7 @@ CORE = [
         priority=600,
         pattern=group(
             r"@\w+",  # stages
-            r"(?i:metadata)\$\w+",  # Snowflake metadata columns
+            r"metadata\$\w+",  # Snowflake metadata columns
             r"\$\d+",  # pg placeholders
             r"\$\w+",  # variables
             r"%(\([^%()]+\))?s",  # psycopg placeholders

--- a/tests/data/unformatted/110_other_identifiers.sql
+++ b/tests/data/unformatted/110_other_identifiers.sql
@@ -2,6 +2,13 @@ select
     v.$1, v.$2, ?3, ?4
   from
     @my_stage( file_format => 'csv_format', pattern => '.*my_pattern.*') v
+select
+    METADATA$FILENAME AS file_name,
+    METADATA$FILE_LAST_MODIFIED AS file_last_modified
+  from
+    @my_stage( file_format => 'csv_format', pattern => '.*my_pattern.*')
 )))))__SQLFMT_OUTPUT__(((((
 select v.$1, v.$2, ?3, ?4
 from @my_stage(file_format => 'csv_format', pattern => '.*my_pattern.*') v
+select metadata$filename as file_name, metadata$file_last_modified as file_last_modified
+from @my_stage(file_format => 'csv_format', pattern => '.*my_pattern.*')

--- a/tests/unit_tests/test_rule.py
+++ b/tests/unit_tests/test_rule.py
@@ -255,6 +255,8 @@ def get_rule(ruleset: List[Rule], rule_name: str) -> Rule:
         (MAIN, "other_identifiers", "$2"),
         (MAIN, "other_identifiers", "?2"),
         (MAIN, "other_identifiers", "$email"),
+        (MAIN, "other_identifiers", "METADATA$FILENAME"),
+        (MAIN, "other_identifiers", "METADATA$FILE_LAST_MODIFIED"),
         (MAIN, "other_identifiers", "@my_unquoted_stage"),
         (MAIN, "other_identifiers", "%s"),
         (MAIN, "other_identifiers", "%(name)s"),


### PR DESCRIPTION
Closes https://github.com/tconbeer/sqlfmt/issues/678

Snowflake metadata columns (`METADATA$FILENAME`, `METADATA$FILE_ROW_NUMBER`, `METADATA$FILE_LAST_MODIFIED`, etc.) were being split into two tokens, inserting a space:

```sql
-- before
select
    metadata $filename as file_name,
    metadata $file_last_modified as file_last_modified,
from @my_stage(file_format => 'json_file_format')
```

```sql
-- after
select
    metadata$filename as file_name,
    metadata$file_last_modified as file_last_modified,
from @my_stage(file_format => 'json_file_format')
```

Snowflake metadata columns (documented [here](https://docs.snowflake.com/en/user-guide/data-engineering/row-timestamps) and [here](https://docs.snowflake.com/en/user-guide/querying-stage)) follow the pattern `METADATA$<column_name>`. sqlfmt was treating `METADATA` and `$<column_name>` as separate tokens, producing invalid SQL with a space between them. This fix ensures all `METADATA$*` identifiers are tokenized as a single unit, regardless of case.