### PR TITLE
fix: log each file path in verbose mode

### DIFF
--- a/src/sqlfmt/api.py
+++ b/src/sqlfmt/api.py
@@ -234,6 +234,15 @@ def _format_one(path: Path, mode: Mode) -> SqlFormatResult:
     Runs format_string on the contents of a single file (found at path). Handles
     potential user errors in formatted code, and returns a SqlfmtResult
     """
+    if mode.verbose:
+        from sqlfmt.report import display_output
+
+        try:
+            display_path = path.relative_to(Path.cwd())
+        except ValueError:
+            display_path = path
+        display_output(f"Reading {display_path}")
+
     source, encoding, utf_bom = _read_path_or_stdin(path, mode)
     try:
         formatted = format_string(source, mode)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -273,3 +273,18 @@ def test_config_does_not_exist(
     assert results.exit_code == 2
     assert "Error: Invalid value for '--config'" in results.stderr
     assert "does not exist" in results.stderr
+
+
+def test_verbose_logging(sqlfmt_runner: CliRunner, preformatted_dir: Path) -> None:
+    # Use single-process mode to ensure verbose output is captured by CliRunner
+    args = f"{preformatted_dir.as_posix()} --verbose --check --no-progressbar --single-process"
+    results = sqlfmt_runner.invoke(sqlfmt_main, args=args)
+    assert results.exit_code == 0
+    # Verbose mode should print each file being processed
+    assert "Reading" in results.stderr or "Processing" in results.stderr
+    # Should see at least one file path in the output
+    sql_files = list(preformatted_dir.glob("*.sql"))
+    assert len(sql_files) > 0
+    # Check that at least one file path appears in verbose output
+    file_found = any(f.name in results.stderr for f in sql_files)
+    assert file_found, f"No file paths found in verbose output: {results.stderr}"

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -281,7 +281,7 @@ def test_verbose_logging(sqlfmt_runner: CliRunner, preformatted_dir: Path) -> No
     results = sqlfmt_runner.invoke(sqlfmt_main, args=args)
     assert results.exit_code == 0
     # Verbose mode should print each file being processed
-    assert "Reading" in results.stderr or "Processing" in results.stderr
+    assert "Reading" in results.stderr
     # Should see at least one file path in the output
     sql_files = list(preformatted_dir.glob("*.sql"))
     assert len(sql_files) > 0


### PR DESCRIPTION
## Summary
- Added a `display_output(f"Reading {display_path}")` call in `_format_one` when verbose mode is enabled, so users can see which file is being processed
- Uses lazy import for `display_output` to avoid circular imports
- Falls back to absolute path when the file is outside the current working directory

Fixes #384

## Test plan
- `pytest tests/ -v` passes (1230 tests, 2 deselected for pre-existing env issue)
- New `test_verbose_logging` verifies that `--verbose --check --no-progressbar --single-process` prints "Reading" and at least one SQL file name to stderr