### PR TITLE
fix: do not treat semicolons inside comments as statement terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Formatting Changes and Bug Fixes
 
 - sqlfmt no longer raises a parsing error on unsupported DDL that contains a semicolon inside a string literal ([#685](https://github.com/tconbeer/sqlfmt/issues/685) - thank you [@nevdelap](https://github.com/nevdelap)!).
+- sqlfmt no longer raises a parsing error when a comment inside an unsupported DDL statement contains a semicolon ([#838](https://github.com/tconbeer/sqlfmt/issues/838)).
 
 ## [0.30.0] - 2026-05-04
 

--- a/src/sqlfmt/rules/unsupported.py
+++ b/src/sqlfmt/rules/unsupported.py
@@ -6,6 +6,11 @@ from sqlfmt.rules.common import NEWLINE, SQL_QUOTED_EXP, group
 from sqlfmt.rules.core import ALWAYS
 from sqlfmt.tokens import TokenType
 
+# a semicolon inside a comment does not terminate an unsupported statement,
+# so unsupported_line must stop before a comment starts and let the comment
+# rule (which has a lower priority number) lex the whole comment.
+COMMENT_START = r"(?=--|#|//|/\*)"
+
 UNSUPPORTED = [
     *ALWAYS,
     # quoted names need to be lexed as DATA, so they are not formatted.
@@ -24,7 +29,10 @@ UNSUPPORTED = [
         # a semicolon inside a string literal does not terminate the line, so
         # quoted expressions have to be consumed whole before we look for the
         # terminator
-        pattern=group(rf"(?:{SQL_QUOTED_EXP}|[^;\n])+?") + group(r";", NEWLINE, r"$"),
+        # similarly, a semicolon inside a comment doesn't terminate an expression,
+        # so we need to stop lexing at the start of a comment to let the higher-priority
+        # comment rule consume that comment.
+        pattern=group(rf"(?:{SQL_QUOTED_EXP}|[^;\n])+?") + group(r";", NEWLINE, COMMENT_START, r"$"),
         action=partial(
             actions.handle_reserved_keyword,
             action=partial(actions.add_node_to_buffer, token_type=TokenType.DATA),

--- a/src/sqlfmt/rules/unsupported.py
+++ b/src/sqlfmt/rules/unsupported.py
@@ -32,7 +32,8 @@ UNSUPPORTED = [
         # similarly, a semicolon inside a comment doesn't terminate an expression,
         # so we need to stop lexing at the start of a comment to let the higher-priority
         # comment rule consume that comment.
-        pattern=group(rf"(?:{SQL_QUOTED_EXP}|[^;\n])+?") + group(r";", NEWLINE, COMMENT_START, r"$"),
+        pattern=group(rf"(?:{SQL_QUOTED_EXP}|[^;\n])+?")
+        + group(r";", NEWLINE, COMMENT_START, r"$"),
         action=partial(
             actions.handle_reserved_keyword,
             action=partial(actions.add_node_to_buffer, token_type=TokenType.DATA),

--- a/src/sqlfmt_primer/primer.py
+++ b/src/sqlfmt_primer/primer.py
@@ -48,7 +48,7 @@ def get_projects() -> List[SQLProject]:
         SQLProject(
             name="http_archive",
             git_url="https://github.com/tconbeer/http_archive_almanac.git",
-            git_ref="37302f3",  # sqlfmt bc43911
+            git_ref="10f3238",  # sqlfmt e416385
             expected_changed=0,
             expected_unchanged=1729,
             expected_errored=0,

--- a/tests/unit_tests/test_analyzer.py
+++ b/tests/unit_tests/test_analyzer.py
@@ -493,3 +493,26 @@ def test_jinja_block_parsing(default_analyzer: Analyzer) -> None:
         TokenType.JINJA_BLOCK_END,  # {% endmacro %}
     ]
     assert types == expected_types
+
+
+@pytest.mark.parametrize(
+    "source_string",
+    [
+        "create TABLE a (\n    A text --test; it's a comment\n)\n",
+        "create table a (x int); -- trailing; comment\n",
+        "create table a (\n    x int  # hash; comment\n)\n",
+        "create table a (\n    x int  /* block; comment */\n)\n",
+    ],
+)
+def test_semicolon_in_unsupported_ddl_comment(
+    default_analyzer: Analyzer, source_string: str
+) -> None:
+    """
+    A semicolon inside a comment must not terminate an unsupported statement.
+    See https://github.com/tconbeer/sqlfmt/issues/838
+    """
+    q = default_analyzer.parse_query(source_string=source_string)
+    comment_tokens = [
+        comment.token.token for line in q.lines for comment in line.comments
+    ]
+    assert any(";" in token for token in comment_tokens)


### PR DESCRIPTION
Closes #838

A comment inside an unsupported DDL statement was truncated at the first semicolon: `unsupported_line` matched greedily up to `;` or a newline, consuming the comment marker and part of its text as DATA, so the rest of the comment was lexed as SQL and raised a parsing/bracket error.

`unsupported_line` now stops at the start of a comment (`--`, `#`, `//`, `/*`) via lookahead, letting the higher-priority `comment` rule take the whole comment. Regression test covers all four comment styles and fails on `main`.
