### PR TITLE
fix: preserve semicolons inside unsupported DDL strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes and Bug Fixes
+
+- sqlfmt no longer raises a parsing error on unsupported DDL that contains a semicolon inside a string literal ([#685](https://github.com/tconbeer/sqlfmt/issues/685) - thank you [@nevdelap](https://github.com/nevdelap)!).
+
 ## [0.30.0] - 2026-05-04
 
 ### Formatting Changes and Bug Fixes

--- a/src/sqlfmt/rules/unsupported.py
+++ b/src/sqlfmt/rules/unsupported.py
@@ -21,7 +21,10 @@ UNSUPPORTED = [
     Rule(
         name="unsupported_line",
         priority=1000,
-        pattern=group(r"[^;\n]+?") + group(r";", NEWLINE, r"$"),
+        # a semicolon inside a string literal does not terminate the line, so
+        # quoted expressions have to be consumed whole before we look for the
+        # terminator
+        pattern=group(rf"(?:{SQL_QUOTED_EXP}|[^;\n])+?") + group(r";", NEWLINE, r"$"),
         action=partial(
             actions.handle_reserved_keyword,
             action=partial(actions.add_node_to_buffer, token_type=TokenType.DATA),

--- a/tests/data/unformatted/999_unsupported_ddl.sql
+++ b/tests/data/unformatted/999_unsupported_ddl.sql
@@ -9,6 +9,11 @@ create table foo as (
 );
 SELECT
     1;
+insert into something
+values
+(101, 'Something with ; a semicolon.'),
+;
+create table bar (a text default 'x ; y');
 )))))__SQLFMT_OUTPUT__(((((
 CREATE PUBLICATION insert_only FOR TABLE mydata
     WITH (publish = 'insert');
@@ -21,3 +26,8 @@ create table foo as (
 );
 select 1
 ;
+insert into something
+values
+(101, 'Something with ; a semicolon.'),
+;
+create table bar (a text default 'x ; y');


### PR DESCRIPTION
## Summary
- treat quoted SQL expressions as atomic while matching unsupported DDL lines
- keep semicolons inside quoted literals from terminating the unsupported-line token
- add regression fixtures for #685 and an unreleased changelog entry

Fixes #685

## Testing
- uv run --no-sync ruff format . --check
- uv run --no-sync ruff check .
- uv run --no-sync mypy --no-incremental
- uv run --no-sync pytest