### PR TITLE
chore: make renovate updates fully automatic

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,26 +1,46 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json", 
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "constraints": {
+    "python": ">=3.10"
+  },
+  "automerge": true,
+  "automergeStrategy": "squash",
+  "platformAutomerge": true,
+  "rebaseWhen": "behind-base-branch",
+  "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": true,
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"],
+    "labels": ["security"]
   },
   "packageRules": [
     {
+      "description": "Never bump the Python interpreter; sqlfmt supports 3.10+",
+      "matchDepNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "Belt and braces: the interpreter pin is managed by hand",
       "matchFileNames": [".python-version"],
       "enabled": false
     },
     {
+      "description": "One PR for everything that isn't a major bump",
       "groupName": "all non-major dependencies",
       "groupSlug": "all-nonmajor",
       "matchPackageNames": ["*"],
-      "matchUpdateTypes": ["minor", "patch", "pin"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": true
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     }
-  ],
-  "extends": [
-    "config:recommended"
   ]
 }


### PR DESCRIPTION
Follow-up to merging #761 and closing #782/#790 (both superseded by the lock refresh).

## Why these PRs got stuck

`lockFileMaintenance` has its own update type, which none of the `packageRules` matched — so the `automerge: true` rules never applied to it and #761 sat open since January. Dependabot's security PRs were a second, uncoordinated source of the same lock bumps, and went stale/red against the strict "branch must be up to date" rule.

## Changes

- **`automerge` at the top level**, so it applies to every update type including lock file maintenance (also set explicitly inside `lockFileMaintenance`). Weekly Monday schedule for the lock refresh.
- **`automergeStrategy: squash`** to match how this repo's history is written, and **`rebaseWhen: behind-base-branch`** so PRs stay mergeable under the strict branch-protection rule instead of going stale.
- **`minimumReleaseAge: "3 days"`** — automerging majors unattended is fine, merging a release that gets yanked two days later is not. Security PRs opt out via `minimumReleaseAge: null`.
- **Renovate owns security updates**: `vulnerabilityAlerts` (automerge, no cool-down, `security` label) plus `osvVulnerabilityAlerts`. Dependabot automated security fixes have been turned off at the repo level; Dependabot *alerts* stay on, since Renovate reads them.
- **Python compatibility**: `constraints: {python: ">=3.10"}` plus a `matchDepNames: ["python"]` rule that disables interpreter bumps anywhere (broader than the old `.python-version` file rule, which is kept as a backstop).

## Also changed outside this PR

Branch protection now requires `Static Analysis` and `sqlfmt primer`. Previously neither was required, so an automerged `ruff`/`mypy`/`black` major could have landed with lint failing or formatting output changed. `ubuntu-latest - 3.10` was already required, so a dep that drops 3.10 support still blocks automerge.

Verified with `renovate-config-validator --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)