### PR TITLE
fix: keep blank lines after comments when formatting is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Formatting Changes and Bug Fixes
+
+- sqlfmt no longer removes blank lines that follow a comment inside a `fmt: off` region ([#673](https://github.com/tconbeer/sqlfmt/issues/673) - thank you [@jmskarda](https://github.com/jmskarda)!).
+
 ## [0.31.0] - 2026-08-03
 
 ### Formatting Changes and Bug Fixes

--- a/src/sqlfmt/actions.py
+++ b/src/sqlfmt/actions.py
@@ -117,13 +117,24 @@ def handle_newline(
 
     However, if we have lexed a standalone comment, we do not want to create
     a Line with only that comment; instead, it must be added to the next Line
-    that contains Nodes
+    that contains Nodes.
+
+    That deferral is a formatting decision, so it must not apply where
+    formatting is disabled: holding the comment back also swallows the newline
+    that terminates it, and then every blank line that follows lands in the same
+    branch and is dropped too. Flushing instead keeps the source verbatim, and
+    costs nothing, because render_with_comments already skips a line whose
+    content is empty once it has rendered a standalone comment.
     """
     nl_token = Token.from_match(source_string, match, TokenType.NEWLINE)
     nl_node = analyzer.node_manager.create_node(
         token=nl_token, previous_node=analyzer.previous_node
     )
-    if analyzer.node_buffer or not analyzer.comment_buffer:
+    if (
+        analyzer.node_buffer
+        or not analyzer.comment_buffer
+        or nl_node.formatting_disabled
+    ):
         analyzer.node_buffer.append(nl_node)
         analyzer.line_buffer.append(
             Line.from_nodes(

--- a/tests/data/preformatted/007_fmt_off_comments.sql
+++ b/tests/data/preformatted/007_fmt_off_comments.sql
@@ -15,3 +15,13 @@ multi
 select 1--nospace
 union all           --lots  of          space
 select 2 /* c */  /* d */     /*e*/
+-- 673: blank lines between standalone comments must survive fmt: off
+
+-- like this one
+
+-- and this one, after two blank lines
+
+
+-- and the blank line before a query must survive, too
+
+select 3

--- a/tests/unit_tests/test_node_manager.py
+++ b/tests/unit_tests/test_node_manager.py
@@ -397,7 +397,14 @@ def test_disabled_formatting(default_mode: Mode) -> None:
     assert selects[3].formatting_disabled
     assert not selects[4].formatting_disabled
 
-    create_publication_line = q.lines[5]
+    # located by content rather than by index: a standalone comment inside a
+    # fmt: off region now flushes its own Line, which shifts every index after it
+    # without changing a byte of rendered output
+    create_publication_line = next(
+        line
+        for line in q.lines
+        if line.nodes and line.nodes[0].token.type is TokenType.DATA
+    )
     assert create_publication_line.formatting_disabled
     assert create_publication_line.nodes
     create_token = create_publication_line.nodes[0].token


### PR DESCRIPTION
Closes #673.

## The bug

Inside a `fmt: off` region, blank lines that follow a comment are deleted:

```sql
-- fmt: off
-- Comment A

-- Comment B
select 1
```

`-- Comment A` and `-- Comment B` end up on adjacent lines. Reproduced on 0.31.0.

## Cause

`handle_newline` deliberately defers a standalone comment so it can attach to the next
`Line` that contains Nodes:

```python
if analyzer.node_buffer or not analyzer.comment_buffer:
    ...  # create a Line
else:
    # standalone comments; don't create a line, since
    # these need to be attached to the next line with contents
    pass
```

The `else` branch drops the newline node entirely. That newline is the one terminating
the comment — but once the comment buffer is non-empty and no nodes have arrived, *every*
subsequent newline lands in the same branch, so the blank lines are discarded too. They
never reach `_remove_extra_blank_lines`, which already honours `line.formatting_disabled`.

This is also why the blank line immediately after the `-- fmt: off` token *does* survive:
`FMT_OFF` is a node, so that newline takes the first branch.

## Fix

Deferring the comment is a formatting decision, so it shouldn't apply where formatting is
disabled. One condition:

```python
if (
    analyzer.node_buffer
    or not analyzer.comment_buffer
    or nl_node.formatting_disabled
):
```

Flushing there costs nothing, because `render_with_comments` already skips rendering a
line whose content is empty once it has emitted a standalone comment — so no duplicate
newline appears. After the flush the comment buffer is empty, so the following blank
line naturally takes the `not analyzer.comment_buffer` path.

## Why formatting-enabled output is untouched

The change is gated on `nl_node.formatting_disabled`, and I checked rather than assumed.
I formatted every fixture in `tests/data/preformatted` and `tests/data/unformatted`
(91 files) through `format_string` and hashed the output, reverting only `actions.py` to
`main` so the fixtures stayed constant and the code change was isolated. **Exactly one
file's output differs: the `007` fixture extended in this PR.** All 91 formatted cleanly,
none errored.

(I originally measured this with `sqlfmt --diff` over those directories. It gave the same
answer, but it is not a sound method here — the fixtures contain the
`)))))__SQLFMT_OUTPUT__(((((` sentinel, which sqlfmt reports as an unmatched bracket, so
most files never produce a diff at all. The hash comparison above is what actually
establishes the claim.)

The unit-test change is a consequence of the same thing: a standalone comment in a
`fmt: off` region now flushes its own `Line`, so `q.lines[5]` in `test_disabled_formatting`
became `q.lines[6]`. I confirmed the *rendered output* of that fixture is unchanged
(diffed before/after) and then made the lookup find the line by its `DATA` token instead of
by index, so it can't shift again.

## Verification

- New coverage appended to `tests/data/preformatted/007_fmt_off_comments.sql`: a single
  blank line between comments, two consecutive blank lines, and a blank line between a
  comment and a query. Preformatted fixtures assert input == output, and
  `test_formatting` also re-formats the result to check idempotency.
- **The assertions were proven to bite.** Reverting the fix fails the `007` case. Dropping
  just the `formatting_disabled` guard (always flushing) fails 17 tests — which is the
  guardrail confirming this must not change enabled-formatting behaviour.
- `uv run pytest` — 1255 passed.
- `uv run ruff format --check .`, `uv run ruff check .`, `uv run mypy` — all clean.
- `uv run sqlfmt_primer` — exits 0.

Happy to adjust the fixture or split the test change out if you'd prefer it separately.
