### PR TITLE
fix: stop a quote run from being lexed as a triple-quoted string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Formatting Changes and Bug Fixes
 
 - sqlfmt no longer removes blank lines that follow a comment inside a `fmt: off` region ([#673](https://github.com/tconbeer/sqlfmt/issues/673) - thank you [@jmskarda](https://github.com/jmskarda)!).
+- sqlfmt no longer raises a parsing error on a run of single quotes that is not a triple-quoted string, like `select '''' || 'quoted_text' || ''''`; it also no longer silently splits longer quote runs such as `''''''''` into two tokens ([#553](https://github.com/tconbeer/sqlfmt/issues/553) - thank you [@albertsgrc](https://github.com/albertsgrc) and [@ifmateus](https://github.com/ifmateus)!).
 
 ## [0.31.0] - 2026-08-03
 

--- a/src/sqlfmt/rules/common.py
+++ b/src/sqlfmt/rules/common.py
@@ -11,8 +11,18 @@ EOL = group(NEWLINE, r"$")
 JINJA_START = group(r"\{[{%#]")
 
 SQL_QUOTED_EXP = group(
-    # tripled single quotes (optionally raw/bytes)
-    r"(rb?|b|br)?'''.*?'''",
+    # tripled single quotes (optionally raw/bytes).
+    #
+    # The body cannot be a lazy .*? — that closes on the FIRST ''' it can reach,
+    # so `select '''' || 'x' || ''''` is read as a triple-quoted string starting
+    # at the first quote and ending three quotes later, stranding a lone quote
+    # that nothing can lex. Matching quote runs explicitly, and refusing a
+    # closer that is itself followed by another quote, makes the alternative
+    # decline rather than mis-close, so the escaped-single-quote alternative
+    # below gets its turn. [^'] rather than [^'\r\n] because these patterns are
+    # compiled with re.DOTALL and multi-line triple-quoted strings must keep
+    # matching.
+    r"(rb?|b|br)?'''(?:[^'](?:[^']|'(?!''))*)?'''(?!')",
     # tripled double quotes
     r'(rb?|b|br)?""".*?"""',
     # possibly escaped double quotes

--- a/src/sqlfmt/rules/common.py
+++ b/src/sqlfmt/rules/common.py
@@ -23,8 +23,8 @@ SQL_QUOTED_EXP = group(
     # compiled with re.DOTALL and multi-line triple-quoted strings must keep
     # matching.
     r"(rb?|b|br)?'''(?:[^'](?:[^']|'(?!''))*)?'''(?!')",
-    # tripled double quotes
-    r'(rb?|b|br)?""".*?"""',
+    # tripled double quotes follow the same quote-run rule as single quotes.
+    r'(rb?|b|br)?"""(?:[^"](?:[^"]|"(?!""))*)?"""(?!")',
     # possibly escaped double quotes
     r'(rb?|b|br|u&|@)?"([^"\\]*(\\.[^"\\]*|""[^"\\]*)*)"',
     # possibly escaped single quotes

--- a/tests/data/preformatted/011_triple_quotes.sql
+++ b/tests/data/preformatted/011_triple_quotes.sql
@@ -1,0 +1,16 @@
+-- see: https://github.com/tconbeer/sqlfmt/issues/553
+-- a quote run that is not a triple-quoted string must not be lexed as one
+select '''' || 'quoted_text' || ''''
+select ''''''''
+select '''3229''' as test
+select '''quoted_text''' as triple
+select '''it's here''' as apostrophe_inside
+select '''''' as empty_triple
+select '''' as escaped_quote
+select '' as empty
+select $$'$$ || 'quoted_text' || $$'$$ as dollar_quoted
+select """a'b""" as triple_double
+select r'''raw''' as raw_triple
+select b'''bytes''' as bytes_triple
+select '''a
+b''' as multiline_triple

--- a/tests/data/preformatted/011_triple_quotes.sql
+++ b/tests/data/preformatted/011_triple_quotes.sql
@@ -2,15 +2,25 @@
 -- a quote run that is not a triple-quoted string must not be lexed as one
 select '''' || 'quoted_text' || ''''
 select ''''''''
+select """" || "quoted_text" || """"
+select """"""""
 select '''3229''' as test
 select '''quoted_text''' as triple
+select """quoted_text""" as triple_double
 select '''it's here''' as apostrophe_inside
 select '''''' as empty_triple
+select """""" as empty_triple_double
 select '''' as escaped_quote
+select """" as escaped_double_quote
 select '' as empty
+select "" as empty_double
 select $$'$$ || 'quoted_text' || $$'$$ as dollar_quoted
-select """a'b""" as triple_double
+select """a'b""" as apostrophe_inside_triple_double
 select r'''raw''' as raw_triple
+select r"""raw""" as raw_triple_double
 select b'''bytes''' as bytes_triple
+select b"""bytes""" as bytes_triple_double
 select '''a
 b''' as multiline_triple
+select """a
+b""" as multiline_triple_double

--- a/tests/functional_tests/test_general_formatting.py
+++ b/tests/functional_tests/test_general_formatting.py
@@ -18,6 +18,7 @@ from tests.util import check_formatting, read_test_data
         "preformatted/008_reserved_names.sql",
         "preformatted/009_empty.sql",
         "preformatted/010_comment_only.sql",
+        "preformatted/011_triple_quotes.sql",
         "preformatted/301_multiline_jinjafmt.sql",
         "preformatted/302_jinjafmt_multiline_str.sql",
         "preformatted/303_jinjafmt_more_mutliline_str.sql",


### PR DESCRIPTION
Closes #553.

## The bug

Quote runs can be misclassified as triple-quoted strings. The reported single-quote form errors:

```sql
select '''' || 'quoted_text' || ''''
```

Longer even runs can also be silently split and reformatted. The same root cause exists for triple-double-quoted strings.

## Cause

The triple-quote alternatives used lazy `.*?`. They close on the first triple they can reach, even when those quotes are part of a longer escaped-quote run. That can strand an unmatched quote or silently split one token into two.

## Fix

Both single- and double-quote alternatives now:

1. Reject a closing triple followed by another matching quote.
2. Reject a body that begins with the matching quote.

This makes a non-triple quote run fall through to the normal quoted-string alternative instead of being partially consumed.

## Coverage

The fixture covers, for both quote styles:

- four- and eight-quote runs;
- normal and empty triple-quoted strings;
- raw and bytes prefixes;
- embedded opposite-quote characters;
- multiline triple-quoted strings;
- ordinary empty quoted strings.

Odd runs remain invalid because they are unterminated.

## Verification

- The expanded fixture failed before the double-quote regex change at the expected unmatched-quote seam.
- Focused functional and lexer suite: 487 passed.
- Full suite: 1256 passed.
- `ruff format --check .`, `ruff check .`, and `mypy src`: clean.
- `sqlfmt_primer`: exits 0.

This keeps the fix in the shared lexer and does not prevent a future dialect-specific split; a dialect split would still need correct triple-quote recognition.